### PR TITLE
Add product clusters to graphql query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Product query to include the `productClusters`.
 
 ## [0.15.0] - 2018-6-14
 ### Added

--- a/react/queries/productsQuery.gql
+++ b/react/queries/productsQuery.gql
@@ -45,5 +45,9 @@ query Products(
         }
       }
     }
+    productClusters {
+      id
+      name
+    }
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add the `productClusters` property in the query.

#### What problem is this solving?
The property is now required in the product summary.

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
