### PR TITLE
Filter buyable products before showing them into shelf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Show only buyable products.
 
 ## [0.18.0] - 2018-08-27
 ### Added

--- a/react/queries/productsQuery.gql
+++ b/react/queries/productsQuery.gql
@@ -41,6 +41,7 @@ query Products(
             NumberOfInstallments
             Name
           }
+          AvailableQuantity
           Price
           ListPrice
         }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Filter buyable products before showing them into shelf

#### What problem is this solving?
Free products (not buyable) and unavailable products were shown.

#### How should this be manually tested?
[Access the workspace](https://estacio--storecomponents.myvtex.com/)

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/15948386/44681772-f23f3b00-aa17-11e8-962d-d148fb761f38.png)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
