### PR TITLE
Fixed infinite content loader when products array is loaded but empty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Inifinite content loader when products array is loaded but empty.
 
 ## [0.18.1] - 2018-08-28
 ### Fixed

--- a/react/ProductList.js
+++ b/react/ProductList.js
@@ -61,7 +61,7 @@ export default class ProductList extends Component {
     const filteredProducts =
       products && products.map(normalizeBuyable).filter(identity)
 
-    return (
+    return products && !products.length ? null : (
       <div className={`${VTEXClasses.MAIN_CLASS} ml7 mr7 pv4 pb7`}>
         <div
           className={`${

--- a/react/RelatedProducts.js
+++ b/react/RelatedProducts.js
@@ -71,13 +71,16 @@ export default class RelatedProducts extends Component {
   render() {
     const { productQuery, productList } = this.props
     const recommendation = this.props.recommendation.split('.').pop()
-    const products =
-      path(['product', 'recommendations', recommendation], productQuery) || []
+    const products = path(
+      ['product', 'recommendations', recommendation],
+      productQuery
+    )
     const productListProps = {
       products,
       loading: productQuery.loading,
       ...productList,
     }
+
     return <ProductList {...productListProps} />
   }
 }

--- a/react/Shelf.js
+++ b/react/Shelf.js
@@ -1,6 +1,7 @@
 import './global.css'
 
 import PropTypes from 'prop-types'
+import { path } from 'ramda'
 import React, { Component } from 'react'
 import { graphql } from 'react-apollo'
 
@@ -16,7 +17,7 @@ import ShelfContent from './ShelfContent'
 class Shelf extends Component {
   render() {
     const { data, productList } = this.props
-    const products = !data || data['error'] ? [] : data.products
+    const products = path(['products'], data)
     const productListProps = {
       products,
       loading: data.loading,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixed infinite content loader when products array is loaded but empty.

#### What problem is this solving?
When a product has no related products, for example, the related products' shelf was shown and the loader never ends.

#### How should this be manually tested?
[Access the workspace](https://estacio--storecomponents.myvtex.com/nintendo-switch/p)

#### Screenshots or example usage

##### Before
![image](https://user-images.githubusercontent.com/15948386/44746782-b1135d80-aae1-11e8-9c92-f101547b4767.png)


##### Now
![image](https://user-images.githubusercontent.com/15948386/44746740-92ad6200-aae1-11e8-9457-2d0fd3cdfb5f.png)


#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
