### PR TITLE
Add page padding to match footer and other page components.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Page padding to match footer and other page components.
 
 ## [0.19.0] - 2018-08-31
 ### Changed

--- a/react/ProductList.js
+++ b/react/ProductList.js
@@ -62,7 +62,7 @@ export default class ProductList extends Component {
       products && products.map(normalizeBuyable).filter(identity)
 
     return products && !products.length ? null : (
-      <div className={`${VTEXClasses.MAIN_CLASS} ml7 mr7 pv4 pb7`}>
+      <div className="vtex-page-padding ml7 mr7 pv4 pb7">
         <div
           className={`${
             VTEXClasses.TITLE_CONTENT_CLASS

--- a/react/RelatedProducts.js
+++ b/react/RelatedProducts.js
@@ -81,6 +81,10 @@ export default class RelatedProducts extends Component {
       ...productList,
     }
 
-    return <ProductList {...productListProps} />
+    return (
+      <div className="vtex-related-products">
+        <ProductList {...productListProps} />
+      </div>
+    )
   }
 }

--- a/react/Shelf.js
+++ b/react/Shelf.js
@@ -23,7 +23,11 @@ class Shelf extends Component {
       loading: data.loading,
       ...productList,
     }
-    return <ProductList {...productListProps} />
+    return (
+      <div className="vtex-shelf">
+        <ProductList {...productListProps} />
+      </div>
+    )
   }
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Added page padding class to allow apps to have the same default padding.

#### What problem is this solving?

Footer had different padding compared to Shelf.

#### How should this be manually tested?

[Access the worskpace](https://padding--storecomponents.myvtex.com/)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/45112345-bbef7300-b11d-11e8-88dc-e1183103ab1b.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
