### PR TITLE
Addition of center tachyon in shelf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Include center tachyon.
+- Center using vtex-page-padding class instead of tachyons.
 
 ## [0.19.4] - 2018-10-19
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Include center tachyon.
 
 ## [0.19.4] - 2018-10-19
 ### Fixed

--- a/react/ProductList.js
+++ b/react/ProductList.js
@@ -61,7 +61,7 @@ export default class ProductList extends Component {
       products && products.map(normalizeBuyable).filter(identity)
 
     return products && !products.length ? null : (
-      <div className="vtex-page-padding mh7-ns pv4 pb7">
+      <div className="pv4 pb7">
         <div
           className={`${
             VTEXClasses.TITLE_CONTENT_CLASS

--- a/react/Shelf.js
+++ b/react/Shelf.js
@@ -24,7 +24,7 @@ class Shelf extends Component {
       ...productList,
     }
     return (
-      <div className="vtex-shelf">
+      <div className="vtex-shelf vtex-page-padding center">
         <ProductList {...productListProps} />
       </div>
     )

--- a/react/global.css
+++ b/react/global.css
@@ -27,6 +27,7 @@
 .vtex-shelf .vtex-slider__arrow-left
 {
     z-index: 1;
+    left: 0.2rem;
 }
 .vtex-shelf .vtex-slider__arrow-right
 {

--- a/react/global.css
+++ b/react/global.css
@@ -27,11 +27,11 @@
 .vtex-shelf .vtex-slider__arrow-left
 {
     z-index: 1;
-    left: -0.5rem;
+    left: -0.2rem;
 }
 .vtex-shelf .vtex-slider__arrow-right
 {
-    right: -0.5rem;
+    right: -0.2rem;
 }
 .vtex-shelf .vtex-slider__dots li button
 {

--- a/react/global.css
+++ b/react/global.css
@@ -27,11 +27,11 @@
 .vtex-shelf .vtex-slider__arrow-left
 {
     z-index: 1;
-    left: 0.2rem;
+    left: -0.5rem;
 }
 .vtex-shelf .vtex-slider__arrow-right
 {
-    right: 0.2rem;
+    right: -0.5rem;
 }
 .vtex-shelf .vtex-slider__dots li button
 {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Addition of center tachyon in shelf.

#### What problem is this solving?
Due use of vtex-page-padding class, the center tachyon is required.

#### How should this be manually tested?
[Access this workspace](https://alignheader--storecomponents.myvtex.com/)

#### Screenshots or example usage
The shelf must be centralized.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
