### PR TITLE
Stop shelf loading when an error happen in the query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.1.4] - 2018-12-12
 ### Fixed
 - Shelf keep loading when a query error happened.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Shelf keep loading when a query error happened.
 
 ## [1.1.3] - 2018-12-04
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "shelf",
   "vendor": "vtex",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "title": "VTEX Shelf",
   "description": "A shelf component",
   "mustUpdateAt": "2019-04-03",

--- a/react/Shelf.js
+++ b/react/Shelf.js
@@ -30,7 +30,7 @@ class Shelf extends Component {
       ...productList,
     }
     
-    if (data.error) {
+    if (data.error || data.loading) {
       return null
     }
 

--- a/react/Shelf.js
+++ b/react/Shelf.js
@@ -24,6 +24,11 @@ class Shelf extends Component {
       isMobile: runtime.hints.mobile,
       ...productList,
     }
+    
+    if (data.error) {
+      return null
+    }
+
     return (
       <div className="vtex-shelf">
         <ProductList {...productListProps} />

--- a/react/Shelf.js
+++ b/react/Shelf.js
@@ -15,6 +15,11 @@ import ShelfContent from './ShelfContent'
  * Shelf Component. Queries a list of products and shows them.
  */
 class Shelf extends Component {
+
+  shouldComponentUpdate(nextProps) {
+    return !Boolean(this.props.data.error && nextProps.data.error)
+  }
+
   render() {
     const { data, productList, runtime } = this.props
     const products = path(['products'], data)


### PR DESCRIPTION
#### What is the purpose of this pull request? What problem is this solving?
Shelf keep loading when an error happen in the query.

#### How should this be manually tested?
[Access this workspace](https://shelfquery--storecomponents.myvtex.com/), there is an error happening in the query of this workspace, so the shelf shouldn't be rendered.

#### Screenshots or example usage
![captura de tela de 2018-12-12 14-45-44](https://user-images.githubusercontent.com/8517023/49890854-de331400-fe23-11e8-9654-3530801c5108.png)


#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
