### PR TITLE
Use H1 element in shelf title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Use H1 element in Shelf Title.
 
 ## [1.5.1] - 2019-01-23
 

--- a/react/ProductList.js
+++ b/react/ProductList.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import { identity, path } from 'ramda'
 import React, { Component, Fragment } from 'react'
 import ProductSummary from 'vtex.product-summary/index'
-import { FormattedMessage } from 'react-intl'
+import { injectIntl, intlShape } from 'react-intl'
 import { productListSchemaPropTypes } from './propTypes'
 import ScrollTypes, { getScrollNames, getScrollValues } from './ScrollTypes'
 import ShelfContent from './ShelfContent'
@@ -44,7 +44,7 @@ function getBuyableSellers(sellers) {
 /**
  * Product List Component. Shows a collection of products.
  */
-export default class ProductList extends Component {
+class ProductList extends Component {
   render() {
     const {
       products,
@@ -55,6 +55,7 @@ export default class ProductList extends Component {
       itemsPerPage,
       summary,
       isMobile,
+      intl,
     } = this.props
 
     const filteredProducts =
@@ -62,9 +63,9 @@ export default class ProductList extends Component {
 
     return products && !products.length ? null : (
       <Fragment>
-        <div className="vtex-shelf__title t-heading-2 fw3 w-100 flex justify-center pt6 pb6 c-muted-1">
-          {titleText || <FormattedMessage id="shelf.title" />}
-        </div>
+        <h1 className="vtex-shelf__title t-heading-2 fw3 w-100 flex justify-center pt6 pb6 c-muted-1 mv0">
+          {titleText || intl.formatMessage({ id: 'shelf.title' })}
+        </h1>
         <ShelfContent
           products={filteredProducts}
           maxItems={maxItems}
@@ -143,5 +144,10 @@ ProductList.propTypes = {
   products: ShelfContent.propTypes.products,
   /** Verifies if is a mobile device. */
   isMobile: PropTypes.bool,
+  /** Internacionalization */
+  intl: intlShape.isRequired,
   ...productListSchemaPropTypes,
 }
+
+export const defaultProps = ProductList.defaultProps
+export default injectIntl(ProductList)

--- a/react/Shelf.js
+++ b/react/Shelf.js
@@ -8,7 +8,7 @@ import { withRuntimeContext } from 'vtex.render-runtime'
 import Container from 'vtex.store-components/Container'
 
 import OrdenationTypes, { getOrdenationNames, getOrdenationValues } from './OrdenationTypes'
-import ProductList from './ProductList'
+import ProductList, { defaultProps } from './ProductList'
 import { productListSchemaPropTypes } from './propTypes'
 import productsQuery from './queries/productsQuery.gql'
 import ShelfContent from './ShelfContent'
@@ -100,7 +100,7 @@ const options = {
     category,
     collection,
     orderBy = OrdenationTypes.ORDER_BY_TOP_SALE_DESC.value,
-    maxItems = ProductList.defaultProps.maxItems,
+    maxItems = defaultProps.maxItems,
   }) => ({
     variables: {
       category,


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
We basically do not use header elements (h1, h2, h3) in our components and it is desirable to use these elements to make our html codebase more meaningful (by adding semantic html elements).

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Shelf title is a H1 element instead of a div with spans.

#### How should this be manually tested?
[https://alves2--storecomponents.myvtex.com/](https://alves2--storecomponents.myvtex.com/)

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
