### PR TITLE
Set ProductName tag as h2 in Shelf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.5.6] - 2019-02-13
 ### Changed
 - Set `ProductName` tag as H2 element.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Set `ProductName` tag as H2 element.
 
 ## [1.5.5] - 2019-02-11
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "shelf",
   "vendor": "vtex",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "title": "VTEX Shelf",
   "description": "A shelf component",
   "mustUpdateAt": "2019-04-03",

--- a/react/ShelfItem.js
+++ b/react/ShelfItem.js
@@ -27,6 +27,7 @@ export default class ShelfItem extends Component {
 
   render() {
     const { item, summary } = this.props
+    summary.name.tag = 'h2'
     return <ProductSummary product={this.normalizeProduct(item)} {...summary} />
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
We basically do not use header elements (h1, h2, h3) in our components and it is desirable to use these elements to make our html codebase more meaningful (by adding semantic html elements).

<!--- Describe your changes in detail. -->

#### What problem is this solving?
`product-summary` `ProductName` in `shelf`  used as H2 element instead of a div.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
[Here](https://alves--storecomponents.myvtex.com/)

#### Screenshots or example usage

#### Types of changes

* [] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
