### PR TITLE
Resize image of shelf for width 500px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Added image resize for 400px.
-
-### Added
-
 - Snapshot tests.
 
 ## [1.8.0] - 2019-02-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Added image resize for 400px.
+- Added image resize for 500px.
 - Snapshot tests.
 
 ## [1.8.0] - 2019-02-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.8.1] - 2019-03-19
+
 ### Added
 
 - Added image resize for 500px.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Added image resize for 400px.
+
+### Added
+
 - Snapshot tests.
 
 ## [1.8.0] - 2019-02-18

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "shelf",
   "vendor": "vtex",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "title": "VTEX Shelf",
   "description": "A shelf component",
   "mustUpdateAt": "2019-04-03",

--- a/react/ShelfItem.js
+++ b/react/ShelfItem.js
@@ -4,6 +4,7 @@ import { path, assocPath } from 'ramda'
 import { ExtensionPoint } from 'vtex.render-runtime'
 
 import { shelfItemPropTypes } from './propTypes'
+import { changeImageUrlSize, toHttps } from './utils/urlHelpers'
 
 /**
  * ShelfItem Component. Normalizes the item received in the props
@@ -20,8 +21,9 @@ export default class ShelfItem extends Component {
       const [seller = { commertialOffer: { Price: 0, ListPrice: 0 } }] = path(['sellers'], sku) || []
       const [referenceId = { Value: '' }] = path(['referenceId'], sku) || []
       const [image = { imageUrl: '' }] = path(['images'], sku) || []
-      const unmixedImage = { ...image, imageUrl: image.imageUrl.replace(/^https?:/, '') }
-      normalizedProduct.sku = { ...sku, seller, referenceId, image: unmixedImage }
+      const resizedImage = changeImageUrlSize(toHttps(image.imageUrl), 250)
+      const normalizedImage = { ...image, imageUrl: resizedImage }
+      normalizedProduct.sku = { ...sku, seller, referenceId, image: normalizedImage }
     }
     return normalizedProduct
   }

--- a/react/ShelfItem.js
+++ b/react/ShelfItem.js
@@ -21,7 +21,7 @@ export default class ShelfItem extends Component {
       const [seller = { commertialOffer: { Price: 0, ListPrice: 0 } }] = path(['sellers'], sku) || []
       const [referenceId = { Value: '' }] = path(['referenceId'], sku) || []
       const [image = { imageUrl: '' }] = path(['images'], sku) || []
-      const resizedImage = changeImageUrlSize(toHttps(image.imageUrl), 400)
+      const resizedImage = changeImageUrlSize(toHttps(image.imageUrl), 500)
       const normalizedImage = { ...image, imageUrl: resizedImage }
       normalizedProduct.sku = { ...sku, seller, referenceId, image: normalizedImage }
     }

--- a/react/ShelfItem.js
+++ b/react/ShelfItem.js
@@ -21,7 +21,7 @@ export default class ShelfItem extends Component {
       const [seller = { commertialOffer: { Price: 0, ListPrice: 0 } }] = path(['sellers'], sku) || []
       const [referenceId = { Value: '' }] = path(['referenceId'], sku) || []
       const [image = { imageUrl: '' }] = path(['images'], sku) || []
-      const resizedImage = changeImageUrlSize(toHttps(image.imageUrl), 250)
+      const resizedImage = changeImageUrlSize(toHttps(image.imageUrl), 400)
       const normalizedImage = { ...image, imageUrl: resizedImage }
       normalizedProduct.sku = { ...sku, seller, referenceId, image: normalizedImage }
     }

--- a/react/utils/urlHelpers.js
+++ b/react/utils/urlHelpers.js
@@ -1,0 +1,56 @@
+export const DEFAULT_WIDTH = 'auto'
+export const DEFAULT_HEIGHT = 'auto'
+export const MAX_WIDTH = 3000
+export const MAX_HEIGHT = 4000
+
+/**
+ * Having the url below as base for the LEGACY file manager,
+ * https://storecomponents.vteximg.com.br/arquivos/ids/155472/Frame-3.jpg?v=636793763985400000
+ * the following regex will match https://storecomponents.vteximg.com.br/arquivos/ids/155472
+ *
+ * Also matches urls with defined sizes like:
+ * https://storecomponents.vteximg.com.br/arquivos/ids/155473-160-auto
+ * @type {RegExp}
+ *
+ * On the new vtex.file-manager isn't necessary replace the URL, just add the param on the querystring, like:
+ * "?width=WIDTH&height=HEIGHT&aspect=true"
+ *
+ */
+const baseUrlRegex = new RegExp(/.+ids\/(\d+)/)
+
+const httpRegex = new RegExp(/http:\/\//)
+
+export function toHttps(url) {
+  return url.replace(httpRegex, 'https://')
+}
+
+export function cleanImageUrl(imageUrl) {
+  const result = baseUrlRegex.exec(imageUrl)
+  if (result.length > 0) return result[0]
+}
+
+function replaceLegacyFileManagerUrl(imageUrl, width, height) {
+  const legacyUrlPattern = '/arquivos/ids/'
+  const isLegacyUrl = imageUrl.includes(legacyUrlPattern)
+  if (!isLegacyUrl) return imageUrl
+  return `${cleanImageUrl(imageUrl)}-${width}-${height}`
+}
+
+export function changeImageUrlSize(
+  imageUrl,
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT
+) {
+  if (!imageUrl) return
+  typeof width === 'number' && (width = Math.min(width, MAX_WIDTH))
+  typeof height === 'number' && (height = Math.min(height, MAX_HEIGHT))
+
+  const normalizedImageUrl = replaceLegacyFileManagerUrl(
+    imageUrl,
+    width,
+    height
+  )
+  const queryStringSeparator = normalizedImageUrl.includes('?') ? '&' : '?'
+
+  return `${normalizedImageUrl}${queryStringSeparator}width=${width}&height=${height}&aspect=true`
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Load image of shelf with width of 500px and not the original size

#### Screenshots or example usage
![Screen Shot 2019-03-19 at 11 38 53](https://user-images.githubusercontent.com/3163867/54614779-bca58200-4a3b-11e9-86f0-8b9832b68c3e.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
