### PR TITLE
search for available item on sku list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Search for first available item on sku list.
 
 ## [1.8.2] - 2019-03-21
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.8.3] - 2019-03-21
 ### Fixed
 - Search for first available item on sku list.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "shelf",
   "vendor": "vtex",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "title": "VTEX Shelf",
   "description": "A shelf component",
   "mustUpdateAt": "2019-04-03",

--- a/react/ShelfItem.js
+++ b/react/ShelfItem.js
@@ -13,10 +13,13 @@ import { changeImageUrlSize, toHttps } from './utils/urlHelpers'
 export default class ShelfItem extends Component {
   static propTypes = shelfItemPropTypes
 
+  findAvailableProduct = item => item.sellers.find(({ commertialOffer = {}}) => commertialOffer.AvailableQuantity > 0)
+
   normalizeProduct(product) {
     if (!product) return null
     const normalizedProduct = { ...product }
-    const [sku] = normalizedProduct.items
+    const items = normalizedProduct.items || []
+    const sku = items.find(this.findAvailableProduct)
     if (sku) {
       const [seller = { commertialOffer: { Price: 0, ListPrice: 0 } }] =
         path(['sellers'], sku) || []


### PR DESCRIPTION
What happened before: we sent to product-summary the first item of the sku list given for that slug.
That sku could be unavailable, it only returned in the search query because another sku is indeed available. So now, we search for this available SKU.

Before:
<img width="1314" alt="Screen Shot 2019-03-19 at 4 39 53 PM" src="https://user-images.githubusercontent.com/4925068/54636648-a57b8a00-4a65-11e9-8b20-e8cf6f0fbf02.png">

Now:
<img width="208" alt="Screen Shot 2019-03-19 at 4 40 47 PM" src="https://user-images.githubusercontent.com/4925068/54636702-c6dc7600-4a65-11e9-8a5e-3cf28556d839.png">

wks to test:
https://fidelis--pilateslovers.myvtex.com/
https://skulist--storecomponents.myvtex.com/

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
