### PR TITLE
Add fixed prices to graphql query

### DIFF
--- a/react/queries/productsQuery.gql
+++ b/react/queries/productsQuery.gql
@@ -46,6 +46,12 @@ query Products(
           Price
           ListPrice
         }
+        fixedPrices {
+          taggedPrice
+          price
+          listPrice
+          quantity
+        }
       }
     }
     productClusters {


### PR DESCRIPTION
#### What is the purpose of this pull request?
To show fixed prices in product summary section we nee to query them from graphql application.

#### What problem is this solving?
Display price breaks of the product in product summary view

#### How should this be manually tested?
This pr should be merged after [this PR](https://github.com/vtex-apps/store-graphql/pull/244)

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ x ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
