### PR TITLE
Send productImpression events to PixelManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.15.0] - 2019-05-17
+
 ### Added
 
 - Send productImpression events to Pixel Manager.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,26 +7,38 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Send productImpression events to Pixel Manager.
+
 ## [1.14.1] - 2019-05-16
 
 ### Fixed
+
 - Export `getSchema` on `Shelf`.
 
 ## [1.14.0] - 2019-05-15
+
 ### Added
+
 - Send productClick events to Pixel Manager.
 
 ## [1.13.1] - 2019-05-13
+
 ### Added
+
 - Adds loading preview to the shelf interfaces.
 
 ### Changed
+
 - Disabled SSR on graphql query. Intended to be a temporary change.
 
 ## [1.13.0] - 2019-05-07
 
 ## [1.12.0] - 2019-04-24
+
 ### Changed
+
 - Scope messages by domain
 
 ## [1.11.2] - 2019-04-15

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "shelf",
   "vendor": "vtex",
-  "version": "1.14.1",
+  "version": "1.15.0",
   "title": "VTEX Shelf",
   "description": "A shelf component",
   "mustUpdateAt": "2019-04-03",

--- a/react/Shelf.js
+++ b/react/Shelf.js
@@ -12,9 +12,7 @@ import OrdenationTypes, {
 import ProductList from './ProductList'
 import { productListSchemaPropTypes } from './propTypes'
 import productsQuery from './queries/productsQuery.gql'
-import ShelfContent, {
-  propTypes as ShelfContentPropTypes,
-} from './ShelfContent'
+import ShelfContent from './ShelfContent'
 
 import shelf from './shelf.css'
 
@@ -54,7 +52,7 @@ Shelf.defaultProps = {
 Shelf.propTypes = {
   /** Graphql data response. */
   data: PropTypes.shape({
-    products: ShelfContentPropTypes.products,
+    products: ShelfContent.propTypes.products,
   }),
   /** Category Id. */
   category: PropTypes.number,

--- a/react/Shelf.js
+++ b/react/Shelf.js
@@ -12,7 +12,9 @@ import OrdenationTypes, {
 import ProductList from './ProductList'
 import { productListSchemaPropTypes } from './propTypes'
 import productsQuery from './queries/productsQuery.gql'
-import ShelfContent from './ShelfContent'
+import ShelfContent, {
+  propTypes as ShelfContentPropTypes,
+} from './ShelfContent'
 
 import shelf from './shelf.css'
 
@@ -52,7 +54,7 @@ Shelf.defaultProps = {
 Shelf.propTypes = {
   /** Graphql data response. */
   data: PropTypes.shape({
-    products: ShelfContent.propTypes.products,
+    products: ShelfContentPropTypes.products,
   }),
   /** Category Id. */
   category: PropTypes.number,

--- a/react/ShelfContent.js
+++ b/react/ShelfContent.js
@@ -11,7 +11,6 @@ import {
   SliderContainer,
   resolveSlidesNumber,
 } from 'vtex.slider'
-import { Pixel } from 'vtex.pixel-manager/PixelContext'
 
 import { getGapPaddingValues } from './paddingEnum'
 import ScrollTypes from './ScrollTypes'
@@ -76,7 +75,6 @@ class ShelfContent extends Component {
 
   componentDidMount() {
     this.setState({ firstRender: false })
-    this.pushPixelProductsImpressions()
   }
 
   arrowRender = ({ orientation, onClick }) => {
@@ -94,19 +92,6 @@ class ShelfContent extends Component {
         <IconCaret orientation={orientation} thin size={20} />
       </div>
     )
-  }
-
-  pushPixelProductsImpressions = () => {
-    const { products } = this.props
-    if (products)
-      products.forEach((product, index) => {
-        this.props.push({
-          event: 'productImpression',
-          list: 'Home Page Shelf',
-          position: index + 1,
-          product,
-        })
-      })
   }
 
   render() {
@@ -142,7 +127,7 @@ class ShelfContent extends Component {
                 key={path(['productId'], item) || index}
                 defaultWidth={DEFAULT_SHELF_ITEM_WIDTH}
               >
-                <ShelfItem item={item} summary={summary} />
+                <ShelfItem item={item} summary={summary} position={index + 1} />
               </Slide>
             ))}
           </Slider>
@@ -168,7 +153,11 @@ class ShelfContent extends Component {
   }
 }
 
-export const propTypes = {
+ShelfContent.defaultProps = {
+  itemsPerPage: 5,
+}
+
+ShelfContent.propTypes = {
   /** List of products */
   products: PropTypes.arrayOf(shelfItemPropTypes.item),
   /** Max Items per page */
@@ -189,10 +178,4 @@ export const propTypes = {
   gap: PropTypes.oneOf(getGapPaddingValues()),
 }
 
-ShelfContent.defaultProps = {
-  itemsPerPage: 5,
-}
-
-ShelfContent.propTypes = propTypes
-
-export default Pixel(ShelfContent)
+export default ShelfContent

--- a/react/ShelfContent.js
+++ b/react/ShelfContent.js
@@ -11,6 +11,7 @@ import {
   SliderContainer,
   resolveSlidesNumber,
 } from 'vtex.slider'
+import { Pixel } from 'vtex.pixel-manager/PixelContext'
 
 import { getGapPaddingValues } from './paddingEnum'
 import ScrollTypes from './ScrollTypes'
@@ -75,6 +76,7 @@ class ShelfContent extends Component {
 
   componentDidMount() {
     this.setState({ firstRender: false })
+    this.pushPixelProductsImpressions()
   }
 
   arrowRender = ({ orientation, onClick }) => {
@@ -92,6 +94,19 @@ class ShelfContent extends Component {
         <IconCaret orientation={orientation} thin size={20} />
       </div>
     )
+  }
+
+  pushPixelProductsImpressions = () => {
+    const { products } = this.props
+    if (products)
+      products.forEach((product, index) => {
+        this.props.push({
+          event: 'productImpression',
+          list: 'Home Page Shelf',
+          position: index + 1,
+          product,
+        })
+      })
   }
 
   render() {
@@ -153,11 +168,7 @@ class ShelfContent extends Component {
   }
 }
 
-ShelfContent.defaultProps = {
-  itemsPerPage: 5,
-}
-
-ShelfContent.propTypes = {
+export const propTypes = {
   /** List of products */
   products: PropTypes.arrayOf(shelfItemPropTypes.item),
   /** Max Items per page */
@@ -178,4 +189,10 @@ ShelfContent.propTypes = {
   gap: PropTypes.oneOf(getGapPaddingValues()),
 }
 
-export default ShelfContent
+ShelfContent.defaultProps = {
+  itemsPerPage: 5,
+}
+
+ShelfContent.propTypes = propTypes
+
+export default Pixel(ShelfContent)

--- a/react/ShelfItem.js
+++ b/react/ShelfItem.js
@@ -51,11 +51,12 @@ class ShelfItem extends Component {
   render() {
     const { item, summary } = this.props
     const newSummary = assocPath(['name', 'tag'], 'h2', summary)
+    const product = this.normalizeProduct(item)
     return (
       <ExtensionPoint
         id="product-summary"
-        product={this.normalizeProduct(item)}
-        actionOnClick={() => this.sendProductClickEvent(item)}
+        product={product}
+        actionOnClick={() => this.sendProductClickEvent(product)}
         {...newSummary}
       />
     )

--- a/react/ShelfItem.js
+++ b/react/ShelfItem.js
@@ -14,7 +14,7 @@ import { changeImageUrlSize, toHttps } from './utils/urlHelpers'
 class ShelfItem extends Component {
   static propTypes = shelfItemPropTypes
 
-  sendProductClickEvent = product => {
+  pushPixelProductClick = product => {
     this.props.push({
       event: 'productClick',
       product: product,
@@ -48,6 +48,22 @@ class ShelfItem extends Component {
     return normalizedProduct
   }
 
+  pushPixelProductImpression = (product, position) => {
+    if (!product) return
+    this.props.push({
+      event: 'productImpression',
+      list: 'Shelf',
+      position,
+      product,
+    })
+  }
+
+  componentDidMount() {
+    const { item, position } = this.props
+    const product = this.normalizeProduct(item)
+    this.pushPixelProductImpression(product, position)
+  }
+
   render() {
     const { item, summary } = this.props
     const newSummary = assocPath(['name', 'tag'], 'h2', summary)
@@ -56,7 +72,7 @@ class ShelfItem extends Component {
       <ExtensionPoint
         id="product-summary"
         product={product}
-        actionOnClick={() => this.sendProductClickEvent(product)}
+        actionOnClick={() => this.pushPixelProductClick(product)}
         {...newSummary}
       />
     )

--- a/react/propTypes.js
+++ b/react/propTypes.js
@@ -53,6 +53,7 @@ export const shelfItemPropTypes = {
     ).isRequired,
   }),
   summary: PropTypes.any,
+  position: PropTypes.number,
 }
 
 export const productListSchemaPropTypes = {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Sending productImpression event to Pixel Manager with the purpose of usage in google-analytics.

A productImpression is an event defined as the moment a user sees a product in a list of products. It occurs before productClick and productDetail events.

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

**Workspace**: https://aguaviva--storecomponents.myvtex.com/

Related: [pixel-manager#19](https://github.com/vtex/pixel-manager/pull/19)