### PR TITLE
Make product object more similar to 'productView' product object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Make product object more similar to `productView` product object.
+
 ## [1.15.0] - 2019-05-17
 
 ### Added

--- a/react/ShelfItem.js
+++ b/react/ShelfItem.js
@@ -48,8 +48,15 @@ class ShelfItem extends Component {
     return normalizedProduct
   }
 
-  pushPixelProductImpression = (product, position) => {
-    if (!product) return
+  pushPixelProductImpression = () => {
+    const { item, position } = this.props
+    const { sku, ...otherFields } = this.normalizeProduct(item)
+
+    const product = {
+      ...otherFields,
+      selectedSku: sku.itemId,
+    }
+
     this.props.push({
       event: 'productImpression',
       list: 'Shelf',
@@ -59,9 +66,7 @@ class ShelfItem extends Component {
   }
 
   componentDidMount() {
-    const { item, position } = this.props
-    const product = this.normalizeProduct(item)
-    this.pushPixelProductImpression(product, position)
+    this.pushPixelProductImpression()
   }
 
   render() {

--- a/react/ShelfItem.js
+++ b/react/ShelfItem.js
@@ -49,6 +49,8 @@ class ShelfItem extends Component {
   }
 
   pushPixelProductImpression = () => {
+    if (!this.props.item) { return }
+
     const { item, position } = this.props
     const { sku, ...otherFields } = this.normalizeProduct(item)
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Make the event API more consistent.

#### What problem is this solving?

Avoid a huge API in the future.

#### How should this be manually tested?

1. Open https://breno--storecomponents.myvtexdev.com/
2. Check `window.pixelManagerEvents` and open the `productImpression` event, check its properties and check that it has `selectedSku`.
3. Navigate to a product page.
4. Check `window.pixelManagerEvents` again and open the `productView` event, check its properties and see that it has `selectedSku` as well.

#### Screenshots or example usage

n/a

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
