### PR TITLE
Add support to i18n content through CMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.16.0] - 2019-05-25
 ### Added
 
 - Add `contentSchemas.json` for definition of content properties

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- Add `contentSchemas.json` for definition of content properties
+- i18n content edition support through CMS
 
 ## [1.15.3] - 2019-05-24
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,6 @@
   "title": "VTEX Shelf",
   "description": "A shelf component",
   "mustUpdateAt": "2019-04-03",
-  "registries": ["smartcheckout"],
   "scripts": {
     "postreleasy": "vtex publish --verbose"
   },

--- a/manifest.json
+++ b/manifest.json
@@ -5,9 +5,7 @@
   "title": "VTEX Shelf",
   "description": "A shelf component",
   "mustUpdateAt": "2019-04-03",
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "scripts": {
     "postreleasy": "vtex publish --verbose"
   },
@@ -17,6 +15,7 @@
     "store": "0.x"
   },
   "dependencies": {
+    "vtex.native-types": "0.x",
     "vtex.store-graphql": "2.x",
     "vtex.store-components": "3.x",
     "vtex.product-summary": "2.x",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "shelf",
   "vendor": "vtex",
-  "version": "1.15.3",
+  "version": "1.16.0",
   "title": "VTEX Shelf",
   "description": "A shelf component",
   "mustUpdateAt": "2019-04-03",

--- a/react/ProductList.js
+++ b/react/ProductList.js
@@ -72,7 +72,7 @@ class ProductList extends Component {
               shelf.title
             } t-heading-2 fw3 w-100 flex justify-center pt7 pb6 c-muted-1`}
           >
-            {titleText || <FormattedMessage id="store/shelf.title" />}
+            <FormattedMessage id={titleText || 'store/shelf.title'}/>
           </div>
         )}
         <ReactResizeDetector handleWidth>
@@ -140,13 +140,14 @@ ProductList.getSchema = props => {
         title: 'admin/editor.shelf.titleText.showTitle',
         type: 'boolean',
         default: ProductList.defaultProps.showTitle,
-        isLayout: true,
+        isLayout: true
       },
       titleText: {
         title: 'admin/editor.shelf.titleText.title',
         type: 'string',
         default: ProductList.defaultProps.titleText,
         isLayout: false,
+        format: 'IOMessage'
       },
     },
   }

--- a/react/ProductList.js
+++ b/react/ProductList.js
@@ -1,8 +1,9 @@
 import PropTypes from 'prop-types'
 import { identity, path } from 'ramda'
 import React, { Component, Fragment } from 'react'
-import { FormattedMessage } from 'react-intl'
 import ReactResizeDetector from 'react-resize-detector'
+import { IOMessage } from 'vtex.native-types'
+
 import { productListSchemaPropTypes } from './propTypes'
 import ScrollTypes, { getScrollNames, getScrollValues } from './ScrollTypes'
 import GapPaddingTypes, {
@@ -72,7 +73,7 @@ class ProductList extends Component {
               shelf.title
             } t-heading-2 fw3 w-100 flex justify-center pt7 pb6 c-muted-1`}
           >
-            <FormattedMessage id={titleText || 'store/shelf.title'}/>
+            <IOMessage defaultId="store/shelf.title" id={titleText} />
           </div>
         )}
         <ReactResizeDetector handleWidth>
@@ -140,7 +141,7 @@ ProductList.getSchema = props => {
         title: 'admin/editor.shelf.titleText.showTitle',
         type: 'boolean',
         default: ProductList.defaultProps.showTitle,
-        isLayout: true
+        isLayout: true,
       },
       titleText: {
         title: 'admin/editor.shelf.titleText.title',

--- a/react/ProductList.js
+++ b/react/ProductList.js
@@ -73,7 +73,7 @@ class ProductList extends Component {
               shelf.title
             } t-heading-2 fw3 w-100 flex justify-center pt7 pb6 c-muted-1`}
           >
-            <IOMessage defaultId="store/shelf.title" id={titleText} />
+            <IOMessage id={titleText} />
           </div>
         )}
         <ReactResizeDetector handleWidth>

--- a/react/ProductList.js
+++ b/react/ProductList.js
@@ -142,14 +142,7 @@ ProductList.getSchema = props => {
         type: 'boolean',
         default: ProductList.defaultProps.showTitle,
         isLayout: true,
-      },
-      titleText: {
-        title: 'admin/editor.shelf.titleText.title',
-        type: 'string',
-        default: ProductList.defaultProps.titleText,
-        isLayout: false,
-        format: 'IOMessage'
-      },
+      }
     },
   }
 }

--- a/react/RelatedProducts.js
+++ b/react/RelatedProducts.js
@@ -82,7 +82,7 @@ RelatedProducts.defaultProps = {
   },
 }
 
-static RelatedProducts.getSchema = props => {
+RelatedProducts.getSchema = props => {
   const productListSchema = ProductList.getSchema(props)
 
   return {

--- a/react/RelatedProducts.js
+++ b/react/RelatedProducts.js
@@ -82,10 +82,8 @@ RelatedProducts.defaultProps = {
   },
 }
 
-RelatedProducts.getSchema = props => {
+static RelatedProducts.getSchema = props => {
   const productListSchema = ProductList.getSchema(props)
-  productListSchema.properties.titleText.default =
-    RelatedProducts.defaultProps.productList.titleText
 
   return {
     title: 'admin/editor.relatedProducts.title',

--- a/react/__mocks__/vtex.native-types/index.js
+++ b/react/__mocks__/vtex.native-types/index.js
@@ -1,0 +1,4 @@
+import React from 'react'
+import { FormattedMessage } from 'react-intl'
+
+export const IOMessage = (props) => <FormattedMessage {...props}/>

--- a/react/__test__/Shelf.test.js
+++ b/react/__test__/Shelf.test.js
@@ -4,6 +4,8 @@ import { render } from '@vtex/test-tools/react'
 import ProductList from '../ProductList'
 import { productMock } from '../__mocks__/productMock'
 import Shelf from '../Shelf'
+const fs = require('fs')
+
 
 describe('Shelf component', () => {
   const renderComponent = customProps => {
@@ -13,8 +15,13 @@ describe('Shelf component', () => {
       arrows: true,
       showTitle: true,
     }
+    
+    // TODO: Remove this later when we have a better way to resolve contentSchemas.json at test-tools
+    const rawData = fs.readFileSync('../store/contentSchemas.json')
+    const contentSchema = JSON.parse(rawData)
+    const titleTextId = contentSchema.definitions.ProductList.properties.titleText.default
 
-    const wrapper = render(<ProductList {...props} {...customProps} />)
+    const wrapper = render(<ProductList titleText={titleTextId} {...props} {...customProps} />)
     return wrapper
   }
 

--- a/react/typings/vtex.native-types.d.ts
+++ b/react/typings/vtex.native-types.d.ts
@@ -1,0 +1,18 @@
+declare module 'vtex.native-types' {
+    import { Component } from 'react'
+    import { InjectedIntl, InjectedIntlProps } from 'react-intl'
+  
+    interface FormatIOMessageParams {
+      id: string
+      intl: InjectedIntl
+    }
+  
+    export const formatIOMessage: (params: FormatIOMessageParams) => string
+  
+    interface IOMessageProps extends InjectedIntlProps {
+      id: string
+    }
+  
+    export const IOMessage: Component<IOMessageProps>
+  }
+  

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -3,7 +3,7 @@
     "ProductList": {
       "properties": {
         "titleText": {
-          "title": "admin/editor.shelf.titleText.title",
+          "title": "admin/editor.shelf.title",
           "$ref": "app:vtex.native-types#/definitions/text",
           "default": "store/shelf.title"
         }

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -3,7 +3,7 @@
     "ProductList": {
       "properties": {
         "titleText": {
-          "title": "admin/editor.shelf.title",
+          "title": "admin/editor.shelf.titleText.title",
           "$ref": "app:vtex.native-types#/definitions/text",
           "default": "store/shelf.title"
         }

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -1,0 +1,13 @@
+{
+  "title": "Content meta-schema",
+  "definitions": {
+    "ProductList": {
+      "properties": {
+        "titleText": { "$ref": "#/definitions/Text" }
+      }    
+    },
+    "Text": {
+      "format": "IOMessage"
+    }
+  }
+}

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -1,13 +1,13 @@
 {
-  "title": "Content meta-schema",
   "definitions": {
     "ProductList": {
       "properties": {
-        "titleText": { "$ref": "#/definitions/Text" }
+        "titleText": {
+          "title": "admin/editor.shelf.titleText.title",
+          "$ref": "app:vtex.native-types#/definitions/text",
+          "default": "store/shelf.title"
+        }
       }    
-    },
-    "Text": {
-      "format": "IOMessage"
     }
   }
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -10,6 +10,11 @@
     "preview": {
       "type": "grid",
       "height": 550
+    },
+    "content": {
+      "properties": {
+        "productList": { "$ref": "#/definitions/ProductList"}
+      }
     }
   },
   "shelf.relatedProducts": {


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Moved schema of content properties from components to `contentSchemas.json`
Using the new `vtex.native-types` to support i18n content insertion through `Storefront`

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
Workspace: https://i18n--storecomponents.myvtex.com/admin/cms/storefront
1 - Click to edit the shelf at storefront sidebar
2 - Edit shelf title and save
3 - Switch language using admin's language switcher
4 - Content should be different for the selected language

#### Screenshots or example usage
![i18n_shelf_1](https://user-images.githubusercontent.com/1594322/58335937-1306b680-7e19-11e9-8880-2c12ee3c2f14.gif)



#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
