### PR TITLE
Enable SSR on graphql query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Stop disabling SSR on graphql query. It was introduced on v1.13.1 as a temporary change.
 
 ## [1.20.1] - 2019-06-27
 

--- a/react/Shelf.js
+++ b/react/Shelf.js
@@ -98,7 +98,6 @@ const options = {
     specificationFilters = [],
     maxItems = ProductList.defaultProps.maxItems,
   }) => ({
-    ssr: false,
     variables: {
       category,
       collection,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Enable SSR on graphql query

#### What problem is this solving?
It was disabled on v1.13.1 and was meant to be a temporary change.

#### How should this be manually tested?
Linking this branch will make shelves be rendered server-side.

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
