### PR TITLE
Hotfix/title schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Hotfix for issue with title schema, which was saving the ID instead of the value. Should be undone once the root issue is fixed.
 
 ## [1.20.2] - 2019-07-03
 ### Fixed 

--- a/react/components/ProductList.js
+++ b/react/components/ProductList.js
@@ -108,7 +108,12 @@ ProductList.getSchema = props => {
         type: 'boolean',
         default: ProductList.defaultProps.showTitle,
         isLayout: true,
-      }
+      },
+      titleText: {
+        title: "admin/editor.shelf.titleText.title",
+        type: 'string',
+        default: "store/shelf.title"
+      },
     },
   }
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -10,11 +10,6 @@
     "preview": {
       "type": "grid",
       "height": 550
-    },
-    "content": {
-      "properties": {
-        "productList": { "$ref": "#/definitions/ProductList"}
-      }
     }
   },
   "shelf.relatedProducts": {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Hotfix for issue with title schema, which was saving the ID instead of the value. Should be undone once the root issue is fixed.

To test, go to https://lbebber--samsungar.myvtex.com/admin/cms/storefront, edit the "Vitrina", and edit the title.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
