### PR TITLE
Make ProductList importable in other apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
+- Send impressions as list and only send them when Shelf is viewed by user.
+
+### Added
 - Make ProductList component importable in other apps
 
 ## [1.20.4] - 2019-07-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Send impressions as list and only send them when Shelf is viewed by user.
+- Make ProductList component importable in other apps
 
 ## [1.20.4] - 2019-07-04
 ### Changed

--- a/react/ProductList.js
+++ b/react/ProductList.js
@@ -1,0 +1,3 @@
+import ProductList from './components/ProductList'
+
+export default ProductList


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make ProductList an importable component that can be used in other apps.

#### What problem is this solving?
I am developing a Wordpress integration app that includes a custom product shelf (products related to a Wordpress article via tagging). Rather than add this very specific shelf type to the Shelf app, the same functionality can be achieved by importing ProductList from the Shelf app and putting a custom wrapper around it.

#### How should this be manually tested?
You can see a custom "Related Products" shelf that is importing ProductList from vtex.shelf here: https://wordpress--storecomponents.myvtex.com/blog/post/13189

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
