### PR TITLE
Fix/default name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Removed the "(Default)" from the default ordering options
 
 ## [1.21.1] - 2019-07-23
 ### Changed

--- a/messages/en.json
+++ b/messages/en.json
@@ -27,7 +27,7 @@
   "admin/editor.shelf.orderType.nameDesc": "Name, descending",
   "admin/editor.shelf.orderType.releaseDate": "Release Date",
   "admin/editor.shelf.orderType.discount": "Discount",
-  "admin/editor.shelf.orderType.relevance": "Relevance (Default)",
+  "admin/editor.shelf.orderType.relevance": "Relevance",
   "admin/editor.shelf.scrollType.byPage": "By Page",
   "admin/editor.shelf.scrollType.oneByOne": "One by One",
   "admin/editor.relatedProducts.title": "Related Products",

--- a/messages/en.json
+++ b/messages/en.json
@@ -4,7 +4,7 @@
   "admin/editor.shelf.category.title": "Category Id",
   "admin/editor.shelf.category.description": "For sub-categories, use \"/\" (e.g. 1/2/3)",
   "admin/editor.shelf.collection.title": "Collection",
-  "admin/editor.shelf.orderBy.title": "List Ordenation",
+  "admin/editor.shelf.orderBy.title": "List Ordination",
   "admin/editor.shelf.maxItems.title": "Max Items",
   "admin/editor.shelf.itemsPerPage.title": "Items Per Page (web)",
   "admin/editor.shelf.gap.title": "Gap between Items",

--- a/messages/es.json
+++ b/messages/es.json
@@ -27,7 +27,7 @@
   "admin/editor.shelf.orderType.nameDesc": "Nombre, descendiendo",
   "admin/editor.shelf.orderType.releaseDate": "Fecha de lanzamiento",
   "admin/editor.shelf.orderType.discount": "Descuento",
-  "admin/editor.shelf.orderType.relevance": "Relevancia (Defecto)",
+  "admin/editor.shelf.orderType.relevance": "Relevancia",
   "admin/editor.shelf.scrollType.byPage": "Por Página",
   "admin/editor.shelf.scrollType.oneByOne": "Uno a Uno",
   "admin/editor.relatedProducts.title": "Productos Relacionados",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -27,7 +27,7 @@
   "admin/editor.shelf.orderType.nameDesc": "Nome, decrescente",
   "admin/editor.shelf.orderType.releaseDate": "Data de lançamento",
   "admin/editor.shelf.orderType.discount": "Desconto",
-  "admin/editor.shelf.orderType.relevance": "Relevância (Padrão)",
+  "admin/editor.shelf.orderType.relevance": "Relevância",
   "admin/editor.shelf.scrollType.byPage": "Por Página",
   "admin/editor.shelf.scrollType.oneByOne": "Um por Um",
   "admin/editor.relatedProducts.title": "Produtos Relacionados",


### PR DESCRIPTION
#### What is the purpose of this pull request?
Removed the "(Default)" from the default ordering options

#### How should this be manually tested?
[workspace](https://iaronaraujo--storecomponents.myvtex.com/admin/cms/storefront)
Open the shelf and check that the list ordination does not have "Relevance (Default)" but only "Relevance".

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/8443580/61899647-484f8380-aef2-11e9-8a33-e8c3dbe2f240.png)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
