### PR TITLE
Add properties field in Products query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added `properties` field in `Products` query.
 
 ## [1.22.0] - 2019-07-25
 ### Added

--- a/react/queries/productsQuery.gql
+++ b/react/queries/productsQuery.gql
@@ -60,5 +60,9 @@ query Products(
       id
       name
     }
+    properties {
+      name,
+      values
+    }
   }
 }

--- a/react/queries/productsQuery.gql
+++ b/react/queries/productsQuery.gql
@@ -61,7 +61,7 @@ query Products(
       name
     }
     properties {
-      name,
+      name
       values
     }
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Get the Product Properties in the Shelf

#### How should this be manually tested?
It should show the properties field in the Product.

[GraphiQL](https://camiloc--storecomponents.myvtex.com/_v/private/vtex.shelf@1.22.0/graphiql/v1?operationName=Products&variables=%7B%0A%20%20%22category%22%3A%20%22%22%2C%0A%20%20%22specificationFilters%22%3A%20%5B%5D%2C%0A%20%20%22orderBy%22%3A%20%22OrderByPriceDESC%22%2C%0A%20%20%22from%22%3A%200%2C%0A%20%20%22to%22%3A%209%0A%7D)

[Query (Too long)](https://paste.ofcode.org/PkPZwUTWbdnNKvzwuriYa3)

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/20094423/62172858-6f92c000-b2f9-11e9-98d9-ecd58e2baa62.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
