### PR TITLE
Fix/intersection observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue with IntersectionObserver on Safari 12.0, making the whole page crash. A polyfill has been added for the time being, while the fix for the issue is not published on polyfill.io.
 
 ## [1.22.2] - 2019-07-31
 ### Removed

--- a/react/Shelf.js
+++ b/react/Shelf.js
@@ -3,6 +3,10 @@ import React, { useMemo, useEffect, useRef } from 'react'
 import { graphql } from 'react-apollo'
 import { Loading, useRuntime } from 'vtex.render-runtime'
 import { usePixel } from 'vtex.pixel-manager/PixelContext'
+/* The IntersectionObserver polyfill from polyfill.io is incorrectly ignoring
+ * Safari 12.0 at the time of writing. This polyfill here should be removed
+ * once that issue is fixed. */
+import 'intersection-observer'
 import { useInView } from 'react-intersection-observer'
 
 import OrdenationTypes, {

--- a/react/package.json
+++ b/react/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "apollo-client": "^2.4.7",
     "classnames": "^2.2.6",
+    "intersection-observer": "^0.7.0",
     "ramda": "^0.25.0",
     "react-intersection-observer": "^8.23.0",
     "react-intl": "^2.7.2",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -2200,6 +2200,11 @@ inherits@2, inherits@^2.0.3, inherits@~2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
+intersection-observer@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.7.0.tgz#ee16bee978db53516ead2f0a8154b09b400bbdc9"
+  integrity sha512-Id0Fij0HsB/vKWGeBe9PxeY45ttRiBmhFyyt/geBdDHBYNctMRTE3dC1U3ujzz3lap+hVXlEcVaB56kZP/eEUg==
+
 intl-format-cache@^2.0.5:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/intl-format-cache/-/intl-format-cache-2.1.0.tgz#04a369fecbfad6da6005bae1f14333332dcf9316"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes issue with IntersectionObserver on Safari 12.0, making the whole page crash. A polyfill has been added for the time being, while the fix for the issue is not published on polyfill.io.

https://lbebber--alssports.myvtex.com

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
