### PR TITLE
Minimum items per page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- New `minPerPage` prop to control the minimum number of items displayed in the Shelf.
+
 ## [1.22.3] - 2019-07-31
 ### Fixed
 - Issue with IntersectionObserver on Safari 12.0, making the whole page crash. A polyfill has been added for the time being, while the fix for the issue is not published on polyfill.io.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- New `minPerPage` prop to control the minimum number of items displayed in the Shelf.
+- New `minItemsPerPage` prop to control the minimum number of items displayed in the Shelf.
 
 ## [1.22.3] - 2019-07-31
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -122,17 +122,17 @@ For `RelatedProducts`:
 
 `ProductListSchema`:
 
-| Prop name      | Type      | Description                                                                                                                       | Default value |
-| -------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `maxItems`     | `Number`  | Maximum number of items in the shelf.                                                                                             | 10            |
-| `scroll`       | `Enum`    | Scroll type of slide transiction. Possible values: `BY_PAGE`, `ONE_BY_ONE`                                                        | `BY_PAGE`     |
-| `arrows`       | `Boolean` | If the arrows are showable or not.                                                                                                | `true`        |
-| `showTitle`    | `Boolean` | Show title of the shelf.                                                                                                          | `true`        |
-| `titleText`    | `String`  | Title of the shelf.                                                                                                               | `null`        |
-| `summary`      | `Object`  | Product Summary schema properties.                                                                                                | -             |
-| `gap`          | `Enum`    | Gap between items. Possible values: `ph0`, `ph3`,`ph5`, `ph7`                                                                     | `ph3`         |
-| `minPerPage`   | `number`  | Minimum amount of slides to be on the screen, can be used to control how many itens will be displayed in the smallest screen size | `1`           |
-| `itemsPerPage` | `number`  | Maximum amount of slides to be on the screen. Can be used to control how many items will be displayed in the biggest screen size  | `5`           |
+| Prop name         | Type      | Description                                                                                                                       | Default value |
+| ----------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `maxItems`        | `Number`  | Maximum number of items in the shelf.                                                                                             | 10            |
+| `scroll`          | `Enum`    | Scroll type of slide transiction. Possible values: `BY_PAGE`, `ONE_BY_ONE`                                                        | `BY_PAGE`     |
+| `arrows`          | `Boolean` | If the arrows are showable or not.                                                                                                | `true`        |
+| `showTitle`       | `Boolean` | Show title of the shelf.                                                                                                          | `true`        |
+| `titleText`       | `String`  | Title of the shelf.                                                                                                               | `null`        |
+| `summary`         | `Object`  | Product Summary schema properties.                                                                                                | -             |
+| `gap`             | `Enum`    | Gap between items. Possible values: `ph0`, `ph3`,`ph5`, `ph7`                                                                     | `ph3`         |
+| `minItemsPerPage` | `number`  | Minimum amount of slides to be on the screen, can be used to control how many itens will be displayed in the smallest screen size | `1`           |
+| `itemsPerPage`    | `number`  | Maximum amount of slides to be on the screen. Can be used to control how many items will be displayed in the biggest screen size  | `5`           |
 
 For `TabbedShelf`:
 

--- a/README.md
+++ b/README.md
@@ -98,14 +98,14 @@ Through the Storefront, you can change the shelf's behavior and interface. Howev
 
 For `Shelf`:
 
-| Prop name              | Type                             | Description                                                                                                             | Default value        |
-| ---------------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | -------------------- |
-| `category`             | `String`                         | Category ID of the listed items in the shelf. For sub-categories, use "/" (e.g. "1/2/3")                                | -                    |
-| `specificationFilters` | `Array(SpecificationFilterItem)` | Specification Filters of the listed items in the shelf. )                                                               | []                   |
-| `collection`           | `Number`                         | Shows the remove button in each item                                                                                    | -                    |
-| `orderBy`              | `Enum`                           | Ordenation type of the items in the shelf. Possible values: `OrderByTopSaleDESC`, `OrderByReleaseDateDESC`, `OrderByBestDiscountDESC`, `OrderByPriceDESC`, `OrderByPriceASC`, `OrderByNameASC`, `OrderByNameDESC` or `''` (default value by relevance) | `''` |
-| `hideUnavailableItems`              | `Boolean`                           | Hides items that are unavailable. | `false` |
-| `productList`          | `ProductListSchema`              | Product list schema. `See ProductListSchema`                                                                            | -                    |
+| Prop name              | Type                             | Description                                                                                                                                                                                                                                            | Default value |
+| ---------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
+| `category`             | `String`                         | Category ID of the listed items in the shelf. For sub-categories, use "/" (e.g. "1/2/3")                                                                                                                                                               | -             |
+| `specificationFilters` | `Array(SpecificationFilterItem)` | Specification Filters of the listed items in the shelf. )                                                                                                                                                                                              | []            |
+| `collection`           | `Number`                         | Shows the remove button in each item                                                                                                                                                                                                                   | -             |
+| `orderBy`              | `Enum`                           | Ordenation type of the items in the shelf. Possible values: `OrderByTopSaleDESC`, `OrderByReleaseDateDESC`, `OrderByBestDiscountDESC`, `OrderByPriceDESC`, `OrderByPriceASC`, `OrderByNameASC`, `OrderByNameDESC` or `''` (default value by relevance) | `''`          |
+| `hideUnavailableItems` | `Boolean`                        | Hides items that are unavailable.                                                                                                                                                                                                                      | `false`       |
+| `productList`          | `ProductListSchema`              | Product list schema. `See ProductListSchema`                                                                                                                                                                                                           | -             |
 
 For `SpecificationFilterItem`:
 | Prop name | Type | Description | Default value |
@@ -122,15 +122,17 @@ For `RelatedProducts`:
 
 `ProductListSchema`:
 
-| Prop name   | Type      | Description                                                                | Default value |
-| ----------- | --------- | -------------------------------------------------------------------------- | ------------- |
-| `maxItems`  | `Number`  | Maximum number of items in the shelf.                                      | 10            |
-| `scroll`    | `Enum`    | Scroll type of slide transiction. Possible values: `BY_PAGE`, `ONE_BY_ONE` | `BY_PAGE`     |
-| `arrows`    | `Boolean` | If the arrows are showable or not.                                         | `true`        |
-| `showTitle` | `Boolean` | Show title of the shelf.                                                   | `true`        |
-| `titleText` | `String`  | Title of the shelf.                                                        | `null`        |
-| `summary`   | `Object`  | Product Summary schema properties.                                         | -             |
-| `gap`       | `Enum`    | Gap between items. Possible values: `ph0`, `ph3`,`ph5`, `ph7`              | `ph3`         |
+| Prop name      | Type      | Description                                                                                                                       | Default value |
+| -------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `maxItems`     | `Number`  | Maximum number of items in the shelf.                                                                                             | 10            |
+| `scroll`       | `Enum`    | Scroll type of slide transiction. Possible values: `BY_PAGE`, `ONE_BY_ONE`                                                        | `BY_PAGE`     |
+| `arrows`       | `Boolean` | If the arrows are showable or not.                                                                                                | `true`        |
+| `showTitle`    | `Boolean` | Show title of the shelf.                                                                                                          | `true`        |
+| `titleText`    | `String`  | Title of the shelf.                                                                                                               | `null`        |
+| `summary`      | `Object`  | Product Summary schema properties.                                                                                                | -             |
+| `gap`          | `Enum`    | Gap between items. Possible values: `ph0`, `ph3`,`ph5`, `ph7`                                                                     | `ph3`         |
+| `minPerPage`   | `number`  | Minimum amount of slides to be on the screen, can be used to control how many itens will be displayed in the smallest screen size | `1`           |
+| `itemsPerPage` | `number`  | Maximum amount of slides to be on the screen. Can be used to control how many items will be displayed in the biggest screen size  | `5`           |
 
 For `TabbedShelf`:
 

--- a/react/components/ProductList.js
+++ b/react/components/ProductList.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types'
-import { identity, path } from 'ramda'
-import React, { Component, Fragment } from 'react'
+import React, { Fragment } from 'react'
 import ReactResizeDetector from 'react-resize-detector'
 import { IOMessage } from 'vtex.native-types'
 
@@ -16,6 +15,7 @@ import shelf from './shelf.css'
 
 const DEFAULT_MAX_ITEMS = 10
 const DEFAULT_ITEMS_PER_PAGE = 5
+const DEFAULT_MIN_ITEMS_PER_PAGE = 1
 
 /**
  * Product List Component. Shows a collection of products.
@@ -26,6 +26,7 @@ const ProductList = ({
   titleText,
   arrows,
   scroll,
+  minItemsPerPage,
   itemsPerPage,
   summary,
   isMobile,
@@ -50,6 +51,7 @@ const ProductList = ({
             maxItems={maxItems}
             arrows={arrows}
             scroll={scroll}
+            minItemsPerPage={minItemsPerPage}
             itemsPerPage={itemsPerPage}
             summary={summary}
             isMobile={isMobile}
@@ -62,7 +64,7 @@ const ProductList = ({
   )
 }
 
-ProductList.getSchema = props => {
+ProductList.getSchema = () => {
   return {
     title: 'admin/editor.shelf.title',
     description: 'admin/editor.shelf.description',
@@ -115,6 +117,7 @@ ProductList.getSchema = props => {
 
 ProductList.defaultProps = {
   maxItems: DEFAULT_MAX_ITEMS,
+  minItemsPerPage: DEFAULT_MIN_ITEMS_PER_PAGE,
   itemsPerPage: DEFAULT_ITEMS_PER_PAGE,
   scroll: ScrollTypes.BY_PAGE.value,
   gap: GapPaddingTypes.SMALL.value,

--- a/react/components/ShelfContent.js
+++ b/react/components/ShelfContent.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import { path, min } from 'ramda'
+import { path } from 'ramda'
 import React, { Component } from 'react'
 import { IconCaret } from 'vtex.store-icons'
 import classNames from 'classnames'
@@ -9,7 +9,6 @@ import {
   Slide,
   Dots,
   SliderContainer,
-  resolveSlidesNumber,
 } from 'vtex.slider'
 
 import { getGapPaddingValues } from '../utils/paddingEnum'
@@ -80,7 +79,7 @@ class ShelfContent extends Component {
   }
 
   render() {
-    const { products, maxItems, scroll, gap, arrows, summary } = this.props
+    const { products, maxItems, scroll, gap, arrows, summary, minItemsPerPage } = this.props
     const { currentSlide } = this.state
 
     const isScrollByPage = scroll === ScrollTypes.BY_PAGE.value
@@ -92,6 +91,7 @@ class ShelfContent extends Component {
       <div className="flex justify-center">
         <SliderContainer className="w-100 mw9">
           <Slider
+            minPerPage={minItemsPerPage}
             perPage={this.perPage}
             onChangeSlide={this.handleChangeSlide}
             currentSlide={currentSlide}
@@ -116,6 +116,7 @@ class ShelfContent extends Component {
             <Dots
               loop
               showDotsPerPage={isScrollByPage}
+              minPerPage={minItemsPerPage}
               perPage={this.perPage}
               currentSlide={currentSlide}
               totalSlides={productList.slice(0, maxItems).length}
@@ -143,6 +144,8 @@ ShelfContent.propTypes = {
   products: PropTypes.arrayOf(shelfItemPropTypes.item),
   /** Max Items per page */
   itemsPerPage: PropTypes.number.isRequired,
+  /** Minimum Items per page */
+  minItemsPerPage: PropTypes.number.isRequired,
   /** Max items in shelf */
   maxItems: PropTypes.number.isRequired,
   /** Show Arrows */

--- a/react/utils/propTypes.js
+++ b/react/utils/propTypes.js
@@ -61,6 +61,8 @@ export const productListSchemaPropTypes = {
   maxItems: PropTypes.number.isRequired,
   /** Maximum number of items in a page. */
   itemsPerPage: PropTypes.number.isRequired,
+  /** Minimum number of items in a page. */
+  minItemsPerPage: PropTypes.number,
   /** Scroll options. */
   scroll: PropTypes.oneOf(getScrollValues()),
   /** If the arrows are showable or not. */


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add support for a `minItemsPerPage` prop to control the minimum number of items displayed on the Shelf, regardless of the client's screen size.

**This is dependent on https://github.com/vtex-apps/slider/pull/33 to work**

#### What problem is this solving?

Gives the user control over how many items are shown on the smallest screen sizes

#### How should this be manually tested?

https://victorhmp--storecomponents.myvtex.com/

#### Screenshots or example usage

![Screen Shot 2019-08-01 at 8 02 33 PM](https://user-images.githubusercontent.com/27777263/62336967-03ef5500-b4a9-11e9-9e72-c2b950709d78.png)


#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.
