### PR TITLE
Make shelf lazy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Make shelf render strategy `lazy`, i.e. component is only fetched client-side.
+
 ## [1.25.1] - 2019-08-06
 ### Changed
 - Use product parsing logic from product-summary.

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -15,7 +15,8 @@
       "properties": {
         "productList": { "$ref": "#/definitions/ProductList"}
       }
-    }
+    },
+    "render": "lazy"
   },
   "shelf.relatedProducts": {
     "required": [


### PR DESCRIPTION
#### What is the purpose of this pull request?

As part of our new strategy for performance, we're testing the hypothesis that server side rendering shouldn't be sensible to segment. In the long run, we will fetch products server-side without generating a simulation and hydrate prices on the client-side. But for now, side-stepping server side rendering of the shelf should make the home page much faster immediately.

#### What problem is this solving?
Slow server-side rendering.

#### How should this be manually tested?
N/A

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
