### PR TITLE
Support for partially showing the next item on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Support for partially showing the next item in the Shelf on mobile.
+
 ## [1.26.0] - 2019-08-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -109,10 +109,11 @@ For `Shelf`:
 | `productList`              | `ProductListSchema`              | Product list schema. `See ProductListSchema`                                                                                                                                                                                                           | -             |
 
 For `SpecificationFilterItem`:
-| Prop name | Type | Description | Default value |
-| ------------------ | ---------- | ------------------------------------------------------------------------ | ---------------- |
-| `id` | `String` | id of Specification Filter to be searched for | "" |
-| `value` | `String` | value of Specification Filter to be searched for | "" |
+
+| Prop name | Type     | Description                                      | Default value |
+| --------- | -------- | ------------------------------------------------ | ------------- |
+| `id`      | `String` | id of Specification Filter to be searched for    | ""            |
+| `value`   | `String` | value of Specification Filter to be searched for | ""            |
 
 For `RelatedProducts`:
 

--- a/README.md
+++ b/README.md
@@ -149,9 +149,10 @@ For `TabbedShelf`:
 | `shelf`      | `Shelf`            | Props for the shelf displayed, same type as `Shelf`. `See Shelf`                      | -             |
 
 For `TabsSchemaItem`:
-| Prop name | Type | Description | Default value |
-| ------------------ | ---------- | ------------------------------------------------------------------------ | ---------------- |
-| `id` | `String` | id of category to be displayed | `-`
+
+| Prop name | Type     | Description                    | Default value |
+| --------- | -------- | ------------------------------ | ------------- |
+| `id`      | `String` | id of category to be displayed | `-`           |
 
 "Since `TabbedShelf` props have a different structure, we add an example of usage below: "
 

--- a/README.md
+++ b/README.md
@@ -123,17 +123,17 @@ For `RelatedProducts`:
 
 `ProductListSchema`:
 
-| Prop name         | Type      | Description                                                                                                                       | Default value |
-| ----------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `maxItems`        | `Number`  | Maximum number of items in the shelf.                                                                                             | 10            |
-| `scroll`          | `Enum`    | Scroll type of slide transiction. Possible values: `BY_PAGE`, `ONE_BY_ONE`                                                        | `BY_PAGE`     |
-| `arrows`          | `Boolean` | If the arrows are showable or not.                                                                                                | `true`        |
-| `showTitle`       | `Boolean` | Show title of the shelf.                                                                                                          | `true`        |
-| `titleText`       | `String`  | Title of the shelf.                                                                                                               | `null`        |
-| `summary`         | `Object`  | Product Summary schema properties.                                                                                                | -             |
-| `gap`             | `Enum`    | Gap between items. Possible values: `ph0`, `ph3`,`ph5`, `ph7`                                                                     | `ph3`         |
-| `minItemsPerPage` | `number`  | Minimum amount of slides to be on the screen, can be used to control how many itens will be displayed in the smallest screen size | `1`           |
-| `itemsPerPage`    | `number`  | Maximum amount of slides to be on the screen. Can be used to control how many items will be displayed in the biggest screen size  | `5`           |
+| Prop name         | Type      | Description                                                                                                                                                                                                                                                                          | Default value |
+| ----------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
+| `maxItems`        | `Number`  | Maximum number of items in the shelf.                                                                                                                                                                                                                                                | 10            |
+| `scroll`          | `Enum`    | Scroll type of slide transiction. Possible values: `BY_PAGE`, `ONE_BY_ONE`                                                                                                                                                                                                           | `BY_PAGE`     |
+| `arrows`          | `Boolean` | If the arrows are showable or not.                                                                                                                                                                                                                                                   | `true`        |
+| `showTitle`       | `Boolean` | Show title of the shelf.                                                                                                                                                                                                                                                             | `true`        |
+| `titleText`       | `String`  | Title of the shelf.                                                                                                                                                                                                                                                                  | `null`        |
+| `summary`         | `Object`  | Product Summary schema properties.                                                                                                                                                                                                                                                   | -             |
+| `gap`             | `Enum`    | Gap between items. Possible values: `ph0`, `ph3`,`ph5`, `ph7`.                                                                                                                                                                                                                       | `ph3`         |
+| `minItemsPerPage` | `Number`  | Minimum amount of slides to be on the screen, can be used to control how many itens will be displayed in the smallest screen size. This value can be a **Float**, which should be a multiple of 0.5 and would indicate that you want to show a "peek" of the next item in the Shelf. | `1`           |
+| `itemsPerPage`    | `Number`  | Maximum amount of slides to be on the screen. Can be used to control how many items will be displayed in the biggest screen size. This value needs to be an **Integer**.                                                                                                             | `5`           |
 
 For `TabbedShelf`:
 

--- a/react/Shelf.js
+++ b/react/Shelf.js
@@ -89,9 +89,9 @@ Shelf.propTypes = {
     products: ShelfContent.propTypes.products,
   }),
   /** Category Id. */
-  category: PropTypes.number,
+  category: PropTypes.string,
   /** Collection Id. */
-  collection: PropTypes.number,
+  collection: PropTypes.string,
   /** Ordenation Type. */
   orderBy: PropTypes.oneOf(getOrdenationValues()),
   /** Hide unavailable items */

--- a/react/components/ShelfContent.js
+++ b/react/components/ShelfContent.js
@@ -76,6 +76,8 @@ class ShelfContent extends Component {
     )
   }
 
+  roundHalf = num => Math.round(num * 2) / 2
+
   render() {
     const {
       products,
@@ -100,14 +102,16 @@ class ShelfContent extends Component {
     const productList =
       !products || !products.length ? Array(maxItems).fill(null) : products
 
+    const roundedMinItems = this.roundHalf(minItemsPerPage)
+
     return (
       <div className="flex justify-center">
         <SliderContainer className="w-100 mw9">
           <Slider
-            minPerPage={minItemsPerPage}
+            minPerPage={roundedMinItems}
             perPage={this.perPage}
             onChangeSlide={this.handleChangeSlide}
-            currentSlide={currentSlide}
+            currentSlide={Math.ceil(currentSlide)}
             arrowRender={arrows && this.arrowRender}
             scrollByPage={isScrollByPage}
             duration={500}
@@ -130,9 +134,9 @@ class ShelfContent extends Component {
               <Dots
                 loop
                 showDotsPerPage={isScrollByPage}
-                minPerPage={minItemsPerPage}
+                minPerPage={roundedMinItems}
                 perPage={this.perPage}
-                currentSlide={currentSlide}
+                currentSlide={Math.ceil(currentSlide)}
                 totalSlides={productList.slice(0, maxItems).length}
                 onChangeSlide={this.handleChangeSlide}
                 classes={{


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add support for partially showing the next item on mobile through the `minItemsPerPage` prop, as the user can now pass a **Float** value to this prop, which is then rounded to the nearest multiple of 0.5 and used to set the initial `currentSlide`.

#### What problem is this solving?

We do not support this feature right now. Although it is possible for the user to pass a float value to `minItemsPerPage`, that would result in strange behavior.

#### How should this be manually tested?

https://victorhmp--storecomponents.myvtex.com/ (on mobile)

#### Screenshots or example usage

![IMG_5E87E4B05373-1](https://user-images.githubusercontent.com/27777263/63100614-d1843400-bf4d-11e9-84ea-995a1b0162c4.jpeg)



#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
