### PR TITLE
Add `measurementUnit`, `unitMultiplier` and `properties` to Product a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `measurementUnit`, `unitMultiplier` and `properties` to Product and ProductRecommendationQuery.
 
 ## [1.26.0] - 2019-08-13
 

--- a/react/queries/productRecommendations.gql
+++ b/react/queries/productRecommendations.gql
@@ -14,6 +14,8 @@ query ProductRecommendations(
     items {
       name
       itemId
+      measurementUnit
+      unitMultiplier
       referenceId {
         Value
       }
@@ -47,6 +49,10 @@ query ProductRecommendations(
           }
         }
       }
+    }
+    properties {
+      name
+      values
     }
   }
 }

--- a/react/queries/productsQuery.gql
+++ b/react/queries/productsQuery.gql
@@ -29,6 +29,8 @@ query Products(
     items {
       name
       itemId
+      measurementUnit
+      unitMultiplier
       referenceId {
         Value
       }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Get the Product Properties, Measurement Unit and Unit Multiplier in the Shelf and RecommendationShelf

#### How should this be manually tested?
[graphiql](https://vtexcamilo--exito.myvtex.com/_v/private/vtex.shelf@1.26.0/graphiql/v1?operationName=ProductRecommendations&variables=%7B%0A%20%20%22identifier%22%3A%20%7B%0A%20%20%20%20%22field%22%3A%20%22id%22%2C%0A%20%20%20%20%22value%22%3A%20%22100000919%22%0A%20%20%7D%2C%0A%20%20%22type%22%3A%20%22view%22%0A%7D)

[Query](https://paste.ofcode.org/MQKpHLh3zPUAd4kg9tkGY7)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/20094423/63125639-c7752c00-bf73-11e9-8dfe-fb4d955d48b3.png)
![image](https://user-images.githubusercontent.com/20094423/63125649-cfcd6700-bf73-11e9-8d5b-6a695b7200af.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
