### PR TITLE
protect against empty img array in parse prod impression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Protect against empty images array in product impression parsing.
 
 ## [1.28.1] - 2019-08-28
 ### Fixed

--- a/react/utils/normalize.js
+++ b/react/utils/normalize.js
@@ -11,9 +11,10 @@ export function parseToProductImpression(product) {
   const items = normalizedProduct.items || []
   const sku = items.find(findAvailableProduct) || items[0]
   if (sku) {
-    const [seller] = pathOr([defaultSeller], ['sellers'], sku)
-    const [referenceId] = pathOr([defaultReference], ['referenceId'], sku)
-    const [image] = pathOr([defaultImage], ['images'], sku)
+    const [seller = defaultSeller] = pathOr([], ['sellers'], sku)
+    const [referenceId = defaultReference] = pathOr([], ['referenceId'], sku)
+    const [image = defaultImage] = pathOr([], ['images'], sku)
+
     const resizedImage = changeImageUrlSize(toHttps(image.imageUrl), 500)
     const normalizedImage = { ...image, imageUrl: resizedImage }
     normalizedProduct.sku = {


### PR DESCRIPTION
#### What is the purpose of this pull request?
If the image array was empty, we would `const [image] = array` so this value was undefined and we would crash.

Now we properly set the default image if it is empty or does not exist for some reason.
https://fidelis--lesters.myvtex.com/

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
