### PR TITLE
Fix related products shelf on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Related Products shelf would not display correctly on mobile.
 
 ## [1.28.3] - 2019-08-29
 

--- a/react/RelatedProducts.js
+++ b/react/RelatedProducts.js
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
 import { path, last } from 'ramda'
 import { Query } from 'react-apollo'
+import { useDevice } from 'vtex.device-detector'
 
 import productRecommendations from './queries/productRecommendations.gql'
 
@@ -20,7 +21,11 @@ const fixRecommendation = recommendation => {
 /**
  * Related Products Component. Queries and shows the related products
  */
-const RelatedProducts = ({ productQuery, productList, recommendation: cmsRecommendation }) => {
+const RelatedProducts = ({
+  productQuery,
+  productList,
+  recommendation: cmsRecommendation,
+}) => {
   const productId = path(['product', 'productId'], productQuery)
   if (!productId) {
     return null
@@ -33,6 +38,7 @@ const RelatedProducts = ({ productQuery, productList, recommendation: cmsRecomme
     }),
     [productId, recommendation]
   )
+  const { isMobile } = useDevice()
 
   return (
     <Query
@@ -41,22 +47,23 @@ const RelatedProducts = ({ productQuery, productList, recommendation: cmsRecomme
       partialRefetch
       ssr={false}
     >
-    {({data, loading}) => {
-      if (!data) {
-        return null
-      }
-      const { productRecommendations } = data
-      const productListProps = {
-        products: productRecommendations || [],
-        loading,
-        ...productList,
-      }
-      return (
-        <div className={shelf.relatedProducts}>
-          <ProductList {...productListProps} />
-        </div>
-      )
-    }}
+      {({ data, loading }) => {
+        if (!data) {
+          return null
+        }
+        const { productRecommendations } = data
+        const productListProps = {
+          products: productRecommendations || [],
+          loading,
+          isMobile,
+          ...productList,
+        }
+        return (
+          <div className={shelf.relatedProducts}>
+            <ProductList {...productListProps} />
+          </div>
+        )
+      }}
     </Query>
   )
 }
@@ -103,7 +110,7 @@ RelatedProducts.getSchema = props => {
           'buy',
           'accessories',
           'viewAndBought',
-          'suggestions'
+          'suggestions',
         ],
         enumNames: [
           'admin/editor.relatedProducts.similars',


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix a bug where the RelatedShelf component would not know if it was being rendered on mobile or not, always displaying the maximum amount of products.

#### What problem is this solving?

Related products shelf broken on mobile.

#### How should this be manually tested?

https://relatedproductsbug--melimeloparis.myvtex.com/portofel-decor-2-bufnite/p

#### Screenshots or example usage

<img width="428" alt="Screen Shot 2019-08-30 at 10 45 37 AM" src="https://user-images.githubusercontent.com/27777263/64025565-5442ec80-cb13-11e9-99cf-4d9e0b342ff4.png">


#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
