### PR TITLE
use search graphql on search queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Start using `search-graphql` for product queries.
 
 ## [1.28.8] - 2019-08-30
 

--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,8 @@
     "vtex.slider": "0.x",
     "vtex.store-icons": "0.x",
     "vtex.pixel-manager": "1.x",
-    "vtex.device-detector": "0.x"
+    "vtex.device-detector": "0.x",
+    "vtex.search-graphql": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/queries/productRecommendations.gql
+++ b/react/queries/productRecommendations.gql
@@ -2,12 +2,12 @@ query ProductRecommendations(
   $identifier: ProductUniqueIdentifier
   $type: CrossSelingInputEnum
 ) {
-  productRecommendations(identifier: $identifier, type: $type) {
+  productRecommendations(identifier: $identifier, type: $type)
+    @context(provider: "vtex.search-graphql") {
     cacheId
     productId
     productName
     description
-    categories
     link
     linkText
     brand
@@ -40,7 +40,7 @@ query ProductRecommendations(
           AvailableQuantity
           Tax
           CacheVersionUsedToCallCheckout
-          Installments (criteria: MAX) {
+          Installments(criteria: MAX) {
             Value
             InterestRate
             TotalValuePlusInterestRate

--- a/react/queries/productsQuery.gql
+++ b/react/queries/productsQuery.gql
@@ -15,13 +15,12 @@ query Products(
     from: $from
     to: $to
     hideUnavailableItems: $hideUnavailableItems
-  ) {
+  ) @context(provider: "vtex.search-graphql") {
     cacheId
     productId
     productName
     productReference
     description
-    categories
     link
     linkText
     brand
@@ -42,7 +41,7 @@ query Products(
       sellers {
         sellerId
         commertialOffer {
-          Installments (criteria: MAX) {
+          Installments(criteria: MAX) {
             Value
             InterestRate
             TotalValuePlusInterestRate


### PR DESCRIPTION
#### What is the purpose of this pull request?
Use search-graphql in search queries.
Stop getting categories resolver in queries

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
https://messages--storecomponents.myvtex.com/apparel---accessories
https://search--exitocol.myvtex.com
https://search--samsungar.myvtex.com
https://search--alssports.myvtex.com/
https://search--parquedpedro.myvtex.com
https://search--newbalance.myvtex.com
https://search--naturitasit.myvtex.com
https://search--gc-wqp6166.myvtex.com/

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
