### PR TITLE
Make shelf render strategy client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Make shelf render strategy `client`, i.e. component assets are fetched client-side with same priority as server-side blocks.
 
 ## [1.28.8] - 2019-08-30
 

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -16,7 +16,7 @@
         "productList": { "$ref": "#/definitions/ProductList"}
       }
     },
-    "render": "lazy"
+    "render": "client"
   },
   "shelf.relatedProducts": {
     "required": [


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make shelf assets subject to asset bundling and therefore load faster, instead of waiting for asset discovery during tree hydration.

#### What problem is this solving?
Lazy is supposed to be used for components that might not be rendered. 

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
