### PR TITLE
Fix/related products on layout bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixes bug where `shelf.relatedProducts` would not work inside a layout block.
 
 ## [1.30.1] - 2019-09-10
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -24,7 +24,8 @@
     "vtex.store-icons": "0.x",
     "vtex.pixel-manager": "1.x",
     "vtex.device-detector": "0.x",
-    "vtex.search-graphql": "0.x"
+    "vtex.search-graphql": "0.x",
+    "vtex.product-context": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/RelatedProducts.js
+++ b/react/RelatedProducts.js
@@ -4,7 +4,7 @@ import { path, last } from 'ramda'
 import { Query } from 'react-apollo'
 import { useDevice } from 'vtex.device-detector'
 
-import { ProductContext } from 'vtex.product-context'
+import { useProduct } from 'vtex.product-context'
 import productRecommendations from './queries/productRecommendations.gql'
 
 import ProductList from './components/ProductList'
@@ -27,9 +27,9 @@ const RelatedProducts = ({
   productList,
   recommendation: cmsRecommendation,
 }) => {
-  const context = useContext(ProductContext)
+  const productContext = useProduct()
 
-  const productId = path(['product', 'productId'], productQuery) || path(['product', 'productId'], context)
+  const productId = path(['product', 'productId'], productQuery) || path(['product', 'productId'], productContext)
 
   if (!productId) {
     return null

--- a/react/RelatedProducts.js
+++ b/react/RelatedProducts.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useContext } from 'react'
+import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
 import { path, last } from 'ramda'
 import { Query } from 'react-apollo'

--- a/react/RelatedProducts.js
+++ b/react/RelatedProducts.js
@@ -1,9 +1,10 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, useContext } from 'react'
 import PropTypes from 'prop-types'
 import { path, last } from 'ramda'
 import { Query } from 'react-apollo'
 import { useDevice } from 'vtex.device-detector'
 
+import { ProductContext } from 'vtex.product-context'
 import productRecommendations from './queries/productRecommendations.gql'
 
 import ProductList from './components/ProductList'
@@ -26,7 +27,10 @@ const RelatedProducts = ({
   productList,
   recommendation: cmsRecommendation,
 }) => {
-  const productId = path(['product', 'productId'], productQuery)
+  const context = useContext(ProductContext)
+
+  const productId = path(['product', 'productId'], productQuery) || path(['product', 'productId'], context)
+
   if (!productId) {
     return null
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes bug where `shelf.relatedProducts` would not work inside a layout block.

The data now comes from `ProductContext` if data from `productQuery` is not available (as is the case when the block is not on the root of `store.product`)

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
https://lbebber--footnotes.myvtex.com/p325-snake-stud-flat-275central-p325/p

Notice that the page has two shelves, one below the product image, and one below that. Both versions work

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
