### PR TITLE
Fix/recommended query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Get `specificationGroups` resolver in productRecommendations query to be able to show badges.
 
 ## [1.31.3] - 2019-10-17
 ### Fixed

--- a/react/queries/productRecommendations.gql
+++ b/react/queries/productRecommendations.gql
@@ -11,6 +11,13 @@ query ProductRecommendations(
     link
     linkText
     brand
+    specificationGroups {
+      name
+      specifications {
+        name
+        values
+      }
+    }
     items {
       name
       itemId


### PR DESCRIPTION
#### What is the purpose of this pull request?
https://fidelis--niazi.myvtex.com/tapete-galant-2-00-x-2-50---sao-carlos/p

ProductRecommendation query was not fetching specificationGroups resolver. This data is needed in order to show the specification badges.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
