### PR TITLE
Add brandId on productRecommendations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `brandId` on the `productRecommendations` query.
 
 ## [1.33.0] - 2019-11-11
 ### Added

--- a/react/queries/productRecommendations.gql
+++ b/react/queries/productRecommendations.gql
@@ -11,6 +11,7 @@ query ProductRecommendations(
     link
     linkText
     brand
+    brandId
     categories
     priceRange {
       sellingPrice {

--- a/react/utils/propTypes.js
+++ b/react/utils/propTypes.js
@@ -11,6 +11,7 @@ export const shelfItemPropTypes = {
     categories: PropTypes.array,
     link: PropTypes.string.isRequired,
     linkText: PropTypes.string.isRequired,
+    brandId: PropTypes.number,
     brand: PropTypes.string.isRequired,
     items: PropTypes.arrayOf(
       PropTypes.shape({


### PR DESCRIPTION
#### What is the purpose of this pull request?
The product brand was not appearing on a product's page's related products shelf
![image](https://user-images.githubusercontent.com/8443580/69154293-833b7f80-0abe-11ea-9d0f-802abc55efd8.png)
Now this is working as intended
![image](https://user-images.githubusercontent.com/8443580/69154329-951d2280-0abe-11ea-9d1a-61df74ebef64.png)

#### How should this be manually tested?

[Workspace](https://iaronaraujo--gympassus.myvtex.com/concept2-rowerg%E2%84%A2-model-d-80/p)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
