### PR TITLE
forces hideUnavailableItems to be always a boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Forces hideUnavailableItems to be a boolean value
 
 ## [1.33.2] - 2019-11-22
 ### Fixed

--- a/react/Shelf.js
+++ b/react/Shelf.js
@@ -107,6 +107,10 @@ Shelf.propTypes = {
 
 const parseFilters = ({id, value}) => `specificationFilter_${id}:${value}`
 
+const toBoolean = (x) => typeof x === 'boolean'
+  ? x
+  : x === "true"
+
 const options = {
   options: ({
     category,
@@ -129,7 +133,7 @@ const options = {
       orderBy,
       from: 0,
       to: maxItems - 1,
-      hideUnavailableItems,
+      hideUnavailableItems: toBoolean(hideUnavailableItems),
       skusFilter,
     },
   }),


### PR DESCRIPTION
#### What is the purpose of this pull request?
After graphql typings when wild, we need to strictly type our query variables

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
