### PR TITLE
Added sliderRoot css handle to Slider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Added sliderRoot css handle
+
 ## [1.33.5] - 2019-12-05
 
 ## [1.33.4] - 2019-12-05

--- a/react/components/ShelfContent.js
+++ b/react/components/ShelfContent.js
@@ -11,7 +11,7 @@ import ShelfItem from './ShelfItem'
 import { shelfContentPropTypes } from '../utils/propTypes'
 import shelf from './shelf.css'
 
-const CSS_HANDLES = ['arrow', 'arrowLeft', 'arrowRight', 'shelfContentContainer', 'sliderContainer', 'slide']
+const CSS_HANDLES = ['arrow', 'arrowLeft', 'arrowRight', 'shelfContentContainer', 'sliderContainer', 'slide', 'sliderRoot']
 const SLIDER_WIDTH_ONE_ELEMENT = 320
 const SLIDER_WIDTH_TWO_ELEMENTS = 500
 const SLIDER_WIDTH_THREE_ELEMENTS = 750
@@ -117,6 +117,9 @@ class ShelfContent extends Component {
             scrollByPage={isScrollByPage}
             duration={500}
             loop
+            classes={{
+              root: cssHandles.sliderRoot
+            }}
             easing="ease"
           >
             {productList.slice(0, maxItems).map((item, index) => (


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Added sliderRoot css handle to Slider
#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Slider root needs to be editable via CSS.
#### How should this be manually tested?
Using this feature, check if slider root has the css handle `sliderRoot`.
#### Screenshots or example usage
Using this feature, check if slider root has the css handle `sliderRoot`.
#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
