### PR TITLE
Fix related products schema by not using ProductList.getSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- `RelatedProducts.getSchema` by replacing call to`ProductList.getSchema` to reading from `ProductList.schema`.
+
 ## [1.35.0] - 2020-01-21
 ### Added
 - `arrows`, `autoplay`, `nativationStep`, `titleText`, `showTitle`, `itemsPerPage`, `minItemsPerPage` and `gap` props to the schema of the Shelf.

--- a/react/RelatedProducts.js
+++ b/react/RelatedProducts.js
@@ -106,10 +106,7 @@ RelatedProducts.defaultProps = {
   },
 }
 
-RelatedProducts.getSchema = props => {
-  const productListSchema = ProductList.getSchema(props)
-
-  return {
+RelatedProducts.schema = {
     title: 'admin/editor.relatedProducts.title',
     description: 'admin/editor.relatedProducts.description',
     type: 'object',
@@ -136,9 +133,8 @@ RelatedProducts.getSchema = props => {
           'admin/editor.relatedProducts.suggestions',
         ],
       },
-      productList: productListSchema,
+    productList: ProductList.schema,
     },
   }
-}
 
 export default RelatedProducts


### PR DESCRIPTION
#### What is the purpose of this pull request?
Read from `ProductList.schema` instead of calling `ProductList.getSchema(props)`.

#### What problem is this solving?
Call to `undefined` function was breaking site-editor.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
