### PR TITLE
Add PriceWithoutDiscount field in products query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `PriceWithoutDiscount` in products query.
+
 ## [1.35.1] - 2020-01-22
 
 ### Fixed

--- a/react/queries/productsQuery.gql
+++ b/react/queries/productsQuery.gql
@@ -73,6 +73,7 @@ query Products(
           }
           AvailableQuantity
           Price
+          PriceWithoutDiscount
           ListPrice
           teasers {
             name


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add the `PriceWithoutDiscount` in the commertial offer field of the products query.

#### What problem is this solving?
We need this value in the new minicart to calculate the totalizers for the order form when the user is offline.

#### How should this be manually tested?
[workspace](https://lucas--storecomponents.myvtex.com/).

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
