### PR TITLE
Fix impression events on `RelatedProducts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Impression events on `RelatedProducts`.
 
 ## [1.35.2] - 2020-01-27
-
 ### Added
 - `PriceWithoutDiscount` in products query.
 
 ## [1.35.1] - 2020-01-22
-
 ### Fixed
 - `RelatedProducts.getSchema` by replacing call to`ProductList.getSchema` to reading from `ProductList.schema`.
 

--- a/react/RelatedProducts.js
+++ b/react/RelatedProducts.js
@@ -3,15 +3,17 @@ import PropTypes from 'prop-types'
 import { path, last } from 'ramda'
 import { Query } from 'react-apollo'
 import { useDevice } from 'vtex.device-detector'
-
+import { ProductListContext } from 'vtex.product-list-context'
 import { useProduct } from 'vtex.product-context'
 import { useCssHandles } from 'vtex.css-handles'
-import productRecommendations from './queries/productRecommendations.gql'
 
+import productRecommendations from './queries/productRecommendations.gql'
 import ProductList from './components/ProductList'
 import { productListSchemaPropTypes } from './utils/propTypes'
 
 const CSS_HANDLES = ['relatedProducts']
+
+const { ProductListProvider } = ProductListContext
 
 // Previous values were in a wrong format with the message string in the enum value.
 const fixRecommendation = recommendation => {
@@ -34,22 +36,21 @@ const RelatedProducts = ({
 
   const productContext = useProduct()
 
-  const productId = path(['product', 'productId'], productQuery) || path(['product', 'productId'], productContext)
+  const productId =
+    path(['product', 'productId'], productQuery) ||
+    path(['product', 'productId'], productContext)
 
   const recommendation = productId ? fixRecommendation(cmsRecommendation) : null
-  const variables = useMemo(
-    () => {
-      if (!productId) {
-        return null
-      }
+  const variables = useMemo(() => {
+    if (!productId) {
+      return null
+    }
 
-      return {
-        identifier: { field: 'id', value: productId },
-        type: recommendation,
-      }
-    },
-    [productId, recommendation]
-  )
+    return {
+      identifier: { field: 'id', value: productId },
+      type: recommendation,
+    }
+  }, [productId, recommendation])
 
   if (!productId) {
     return null
@@ -75,7 +76,9 @@ const RelatedProducts = ({
         }
         return (
           <div className={handles.relatedProducts}>
-            <ProductList {...productListProps} />
+            <ProductListProvider>
+              <ProductList {...productListProps} />
+            </ProductListProvider>
           </div>
         )
       }}
@@ -107,34 +110,34 @@ RelatedProducts.defaultProps = {
 }
 
 RelatedProducts.schema = {
-    title: 'admin/editor.relatedProducts.title',
-    description: 'admin/editor.relatedProducts.description',
-    type: 'object',
-    properties: {
-      recommendation: {
-        title: 'admin/editor.relatedProducts.recommendation',
-        description: 'admin/editor.relatedProducts.recommendation.description',
-        type: 'string',
-        default: RelatedProducts.defaultProps.recommendation,
-        enum: [
-          'similars',
-          'view',
-          'buy',
-          'accessories',
-          'viewAndBought',
-          'suggestions',
-        ],
-        enumNames: [
-          'admin/editor.relatedProducts.similars',
-          'admin/editor.relatedProducts.view',
-          'admin/editor.relatedProducts.buy',
-          'admin/editor.relatedProducts.accessories',
-          'admin/editor.relatedProducts.viewAndBought',
-          'admin/editor.relatedProducts.suggestions',
-        ],
-      },
-    productList: ProductList.schema,
+  title: 'admin/editor.relatedProducts.title',
+  description: 'admin/editor.relatedProducts.description',
+  type: 'object',
+  properties: {
+    recommendation: {
+      title: 'admin/editor.relatedProducts.recommendation',
+      description: 'admin/editor.relatedProducts.recommendation.description',
+      type: 'string',
+      default: RelatedProducts.defaultProps.recommendation,
+      enum: [
+        'similars',
+        'view',
+        'buy',
+        'accessories',
+        'viewAndBought',
+        'suggestions',
+      ],
+      enumNames: [
+        'admin/editor.relatedProducts.similars',
+        'admin/editor.relatedProducts.view',
+        'admin/editor.relatedProducts.buy',
+        'admin/editor.relatedProducts.accessories',
+        'admin/editor.relatedProducts.viewAndBought',
+        'admin/editor.relatedProducts.suggestions',
+      ],
     },
-  }
+    productList: ProductList.schema,
+  },
+}
 
 export default RelatedProducts


### PR DESCRIPTION
#### What is the purpose of this pull request?
`productImpression` event wasn't being sent for items on the `RelatedProducts` shelf. This PR fixes this.

#### How should this be manually tested?
[Workspace](https://iaronaraujo--alssports.myvtex.com/patagn-shirt-fitz-roy-horizons-resp/p)
See the related products shelf then go on console, type `pixelManagerEvents` and check that a `productImpression` event was sent with the products seen.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
