### PR TITLE
Removed `useInView`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- `useInView` on `ShelfItem` since this logic was moved to the `product-summary` now.
 
 ## [1.35.3] - 2020-02-06
 ### Fixed

--- a/react/components/ShelfItem.js
+++ b/react/components/ShelfItem.js
@@ -1,12 +1,9 @@
-import React, { useMemo, useCallback, useEffect } from 'react'
+import React, { useMemo, useCallback } from 'react'
 import { assocPath } from 'ramda'
-import { useInView } from 'react-intersection-observer'
-import { ProductListContext } from 'vtex.product-list-context'
 import ProductSummary from 'vtex.product-summary/ProductSummaryCustom'
 import { ExtensionPoint } from 'vtex.render-runtime'
 import { usePixel } from 'vtex.pixel-manager/PixelContext'
 
-const { useProductListDispatch } = ProductListContext
 /**
  * ShelfItem Component. Normalizes the item received in the props
  * to adapt to the extension point prop.
@@ -28,24 +25,9 @@ const ShelfItem = ({ item, summary }) => {
     })
   }, [product, push])
 
-  const [inViewRef, inView] = useInView({
-    // Triggers the event when the element is 75% visible
-    threshold: 0.75,
-    triggerOnce: true,
-  })
-
-  const dispatch = useProductListDispatch()
-
-  useEffect(() => {
-    if (inView) {
-      dispatch({ type: 'SEND_IMPRESSION', args: { product: product } })
-    }
-  }, [dispatch, inView, product])
-
   return (
     <ExtensionPoint
       id="product-summary"
-      containerRef={inViewRef}
       product={product}
       actionOnClick={pushPixelProductClick}
       {...newSummary}


### PR DESCRIPTION
#### What is the purpose of this pull request?
This hook isn't needed anymore since this logic was moved to the `product-summary`

#### How should this be manually tested?

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/)
Go to the console, type `pixelManagerEvents` and check that the `productImpression` events are still being sent correctly.

