### PR TITLE
Fix/loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue where there would be an infinite `setState` loop if there were multiple items per page and autoplay enabled.
 
 ## [1.35.4] - 2020-02-10
 ### Removed

--- a/react/components/ShelfContent.js
+++ b/react/components/ShelfContent.js
@@ -6,6 +6,7 @@ import { NoSSR } from 'vtex.render-runtime'
 import { Slider, Slide, Dots, SliderContainer } from 'vtex.slider'
 import { withCssHandles } from 'vtex.css-handles'
 import { resolvePaginationDotsVisibility } from '../utils/resolvePaginationDots'
+import resolveSlidesNumber from '../utils/resolveSlidesNumber'
 import ScrollTypes from '../utils/ScrollTypes'
 import ShelfItem from './ShelfItem'
 import { shelfContentPropTypes } from '../utils/propTypes'
@@ -57,8 +58,22 @@ class ShelfContent extends Component {
     const productList =
       !products || !products.length ? Array(maxItems).fill(null) : products
     const totalItems = productList.slice(0, maxItems).length
-    const customPerPage = (!isMobile && itemsPerPage) || this.perPage
+    let customPerPage = (!isMobile && itemsPerPage) || this.perPage
+
+    /** Fix for a case where customPerPage would come from this.perPage,
+     * which would be an object, and would cause nextSlide to be cast into
+     * a string in the sum below. This was a quick fix, feel free to improve
+     * this code later on if you judge it necessary.
+    */
+    if (typeof customPerPage !== 'number') {
+      let minPerPage = this.props.minItemsPerPage
+      if (typeof minPerPage !== 'number') {
+        minPerPage = 1
+      }
+      customPerPage = resolveSlidesNumber(this.roundHalf(minPerPage), customPerPage, isMobile)
+    }
     const nextSlide = ((currentSlide) % totalItems) + customPerPage
+
     this.handleChangeSlide(nextSlide)
   }
 

--- a/react/utils/resolveSlidesNumber.js
+++ b/react/utils/resolveSlidesNumber.js
@@ -1,0 +1,38 @@
+/**
+ * This function returns the number of slides to show depending on the size of the window.
+ * If you pass a number it just returns that number.
+ * If you pass an object it will return the number of slides of the closest breakpoint to the size of the window.
+ * If you pass for example
+ * perPage = {
+ *   400: 2,
+ *   1000: 3
+ * }
+ *
+ * If the size of the window is something between 400px and 999px if will return 2,
+ * if it is 1000px or bigger, it will return 3, and if it is smaller than 400px it
+ * will return the default value; that is, 1.
+ * @param {number|object} perPage
+ * @param {number|undefined} minPerPage
+ */
+function resolveSlidesNumber(minPerPage, perPage, isMobile) {
+  let result = minPerPage || 1
+  if (typeof perPage === 'number') {
+    result = perPage
+  } else if (typeof perPage === 'object') {
+    const innerWidth = window && window.innerWidth
+
+    /** If it's on SSR, use placeholder screen sizes to get an approximate
+     * guess of how many items are displayed per page */
+    const windowSize = innerWidth || (isMobile ? 320 : 1024)
+
+    for (const viewport in perPage) {
+      if (windowSize >= viewport) {
+        result = perPage[viewport]
+      }
+    }
+  }
+  return result < minPerPage ? minPerPage : result
+}
+
+export default resolveSlidesNumber
+


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes issue where there would be an infinite `setState` loop if there were multiple items per page and autoplay enabled.

To test, open this page on desktop mode, and then set it to mobile mode. There shouldn't be any infinite setState loop:
https://lbebber--samsungar.myvtex.com/

Compare with the page below, where doing the same will hang your browser tab:
https://samsungar.myvtex.com/

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
