### PR TITLE
Feature/add variations to product recommendations query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `variations` to the `productRecommendations` query.
 
 ## [1.36.0] - 2020-02-27
 ### Added

--- a/react/queries/productRecommendations.gql
+++ b/react/queries/productRecommendations.gql
@@ -45,6 +45,10 @@ query ProductRecommendations(
         imageUrl
         imageText
       }
+      variations {
+        name
+        values
+      }
       sellers {
         sellerId
         sellerName


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add the `variations` property to the `productRecommendations` query, just like the `productsQuery`.

#### What problem is this solving?
This keeps the `useProductSummary` hook from `vtex.product-summary-context` with the same schema for usings in `shelf` and `shelf.relatedProducts`.

#### How should this be manually tested?
https://brunomoreira--storecomponents.myvtex.com/blouse-with-knot/p
```
curl --location --request GET 'https://brunomoreira--storecomponents.myvtex.com/_v/segment/graphql/v1?operationName=ProductRecommendations&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%224522f5abea045b80ba698d45564253cb604e8f6c8438ad5d4aa2b746fe05f21c%22%2C%22sender%22%3A%22vtex.shelf%401.x%22%2C%22provider%22%3A%22vtex.search-graphql%400.x%22%7D%2C%22variables%22%3A%22eyJpZGVudGlmaWVyIjp7ImZpZWxkIjoiaWQiLCJ2YWx1ZSI6IjIwMDAwMDgifSwidHlwZSI6InZpZXcifQ%3D%3D%22%7D' \
--header 'content-type: application/json'
```

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/27451066/76024491-ff40c280-5f09-11ea-8b19-8acf90600b2b.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
