### PR TITLE
Fix Number of Related Products in Mobile View

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-- Fixed number of related products in mobile view
+- `isMobile` prop passed to `ProductList` by `RelatedProducts` component would always be `false` due to object spreading order.
 
 ## [1.39.0] - 2020-06-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed number of related products in mobile view
+
 ## [1.39.0] - 2020-06-15
 ### Added
 - `taxPercentage` and `Tax` field to product query.

--- a/react/RelatedProducts.js
+++ b/react/RelatedProducts.js
@@ -73,7 +73,7 @@ const RelatedProducts = ({
           products: productRecommendations || [],
           loading,
           ...productList,
-	        isMobile,
+          isMobile,
         }
         return (
           <div className={handles.relatedProducts}>

--- a/react/RelatedProducts.js
+++ b/react/RelatedProducts.js
@@ -73,7 +73,7 @@ const RelatedProducts = ({
           products: productRecommendations || [],
           loading,
           ...productList,
-	  isMobile,
+	        isMobile,
         }
         return (
           <div className={handles.relatedProducts}>

--- a/react/RelatedProducts.js
+++ b/react/RelatedProducts.js
@@ -72,8 +72,8 @@ const RelatedProducts = ({
         const productListProps = {
           products: productRecommendations || [],
           loading,
-          isMobile,
           ...productList,
+	  isMobile,
         }
         return (
           <div className={handles.relatedProducts}>


### PR DESCRIPTION
#### What problem is this solving?

The mobile view of the product detail page shows 5 items per row in the related product shelf. The `isMobile` prop passed by the `RelatedProducts` always carries the value `false` because of the order of object destructuring.

#### How to test it?

Check the related product shelf of the following workspace.

[Workspace](https://showtogether--sbdind.myvtex.com/robotic-welder-2/p)

#### Screenshots or example usage:

##### Before:

![related-shelf-mobile-issue](https://user-images.githubusercontent.com/42151054/86489412-e6460200-bd81-11ea-81d8-397b73757e9b.png)

##### After:

![related-shelf-mobile-fix](https://user-images.githubusercontent.com/42151054/86485194-b42ea300-bd75-11ea-9ef1-1e43f09c7baa.png)
