### PR TITLE
Remove shelf blocks from the new cms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Remove `description` from `Shelf` content schema definition to remove it from the new CMS.
 
 ## [1.39.0] - 2020-06-15
 ### Added

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -2,7 +2,6 @@
   "definitions": {
     "Shelf": {
       "title": "admin/editor.shelf.title",
-      "description": "admin/editor.shelf.description",
       "type": "object",
       "dependencies": {
         "advancedProperties": {


### PR DESCRIPTION
#### What problem is this solving?

The shelf had three blocks with the same ref to `#definitions/Shelf` in `contentSchemas.json`, and that schema had the `title` and `description` attributes, which is the thing that makes a block compliant with the new cms. So we are removing the description from this definition and create a new definition to related products

#### How to test it?
[site-editor with the changes made](https://cmscomponents2--storecomponents.myvtex.com/admin/cms/site-editor/)
[site-editor without the changes made](https://cmswithoutchanges--storecomponents.myvtex.com/admin/cms/site-editor/)
[new cms with the changes made](https://cmscomponents2--storecomponents.myvtex.com/admin/app/new-cms/edit/new)
[new cms without the changes made](https://cmswithoutchanges--storecomponents.myvtex.com/admin/app/new-cms/edit/new)

##### Site Editor

1. Open the workspace
2.  Click on the Shelf or Related Products
3. You should see the same schema in both workspaces with or without the changes made on Shelf

##### New CMS

1. Open the workspace
2. Click on the Plus button to add a new block to the page
3. In the workspace with changes, you shouldn't see Shelf blocks, and without changes, you should see the Shelf blocks

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/xHMIDAy1qkzNS/giphy.gif)
