### PR TITLE
Add new CSS handle for the active dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add new CSS handle for the active dot.
 
 ## [1.40.1] - 2020-07-22
 ### Changed

--- a/react/components/ShelfContent.js
+++ b/react/components/ShelfContent.js
@@ -5,7 +5,7 @@ import { IconCaret } from 'vtex.store-icons'
 import classNames from 'classnames'
 import { NoSSR } from 'vtex.render-runtime'
 import { Slider, Slide, Dots, SliderContainer } from 'vtex.slider'
-import { withCssHandles } from 'vtex.css-handles'
+import { withCssHandles, applyModifiers } from 'vtex.css-handles'
 
 import { resolvePaginationDotsVisibility } from '../utils/resolvePaginationDots'
 import resolveSlidesNumber from '../utils/resolveSlidesNumber'
@@ -21,6 +21,7 @@ const CSS_HANDLES = [
   'shelfContentContainer',
   'sliderContainer',
   'slide',
+  'dot--isActive',
 ]
 const SLIDER_WIDTH_ONE_ELEMENT = 320
 const SLIDER_WIDTH_TWO_ELEMENTS = 500
@@ -202,7 +203,7 @@ class ShelfContent extends Component {
                   root: 'pt4',
                   notActiveDot: 'bg-muted-3',
                   dot: classNames(shelf.dot, 'mh2 mv0 pointer br-100'),
-                  activeDot: 'bg-emphasis',
+                  activeDot: `${cssHandles['dot--isActive']} bg-emphasis`,
                 }}
               />
             </NoSSR>

--- a/react/components/ShelfContent.js
+++ b/react/components/ShelfContent.js
@@ -5,7 +5,7 @@ import { IconCaret } from 'vtex.store-icons'
 import classNames from 'classnames'
 import { NoSSR } from 'vtex.render-runtime'
 import { Slider, Slide, Dots, SliderContainer } from 'vtex.slider'
-import { withCssHandles, applyModifiers } from 'vtex.css-handles'
+import { withCssHandles } from 'vtex.css-handles'
 
 import { resolvePaginationDotsVisibility } from '../utils/resolvePaginationDots'
 import resolveSlidesNumber from '../utils/resolveSlidesNumber'


### PR DESCRIPTION
#### What problem is this solving?

Add class isActive to active dot.

#### How to test it?

https://produto--zonasul.myvtex.com/v-tto-fra-l-miquel-syrah-grenache-750ml/p

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/284515/88331205-fad34580-cd02-11ea-9210-f40c3f0f6fae.png)

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
