### PR TITLE
Add `spotPrice` to `productRecommendations.gql`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `spotPrice` to Product Recommendations query.
 
 ## [1.41.1] - 2020-07-23
 ### Fixed

--- a/react/queries/productRecommendations.gql
+++ b/react/queries/productRecommendations.gql
@@ -77,6 +77,7 @@ query ProductRecommendations(
           }
           Price
           ListPrice
+          spotPrice
           PriceWithoutDiscount
           RewardValue
           PriceValidUntil


### PR DESCRIPTION
#### What problem is this solving?
Showing the spot price also in `shelf.relatedProducts`


#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[with change](https://lucas--polishop.myvtex.com/escova-modeladora-rotating-air-brush-diamond-brilliance-conair/p)
[currently](https://polishop.myvtex.com/escova-modeladora-rotating-air-brush-diamond-brilliance-conair/p)

#### Screenshots or example usage:
![image](https://user-images.githubusercontent.com/27451066/91777854-524cb700-ebc7-11ea-80af-0bab4df7bfed.png)

#### Describe alternatives you've considered, if any.


#### Related to / Depends on


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/l2JdTVJqNW9kf6Lfy/giphy.gif)
