### PR TITLE
Feature/add seller name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- sellerName to `Products` query.
 
 ## [1.41.1] - 2020-07-23
 ### Fixed

--- a/react/queries/productsQuery.gql
+++ b/react/queries/productsQuery.gql
@@ -75,6 +75,7 @@ query Products(
       }
       sellers {
         sellerId
+        sellerName
         commertialOffer {
           Installments(criteria: MAX) {
             Value


### PR DESCRIPTION
#### What problem is this solving?
Added sellerName to shelf `Product` query, it's a extremely important data to marketplaces.

#### How to test it?

Access the workspace below and open the console to see the sellerName info as the print shows.

[Workspace](https://sellershelf--carrefourbrfood.myvtex.com/)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/59736416/92024877-218a9000-ed35-11ea-8bc0-e6ab46a16b0d.png)
