### PR TITLE
spotPrice to `Products` query.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- spotPrice to `Products` query.
 
 ## [1.42.0] - 2020-09-08
 ### Added

--- a/react/queries/productsQuery.gql
+++ b/react/queries/productsQuery.gql
@@ -88,6 +88,7 @@ query Products(
           Price
           PriceWithoutDiscount
           ListPrice
+          spotPrice
           Tax
           taxPercentage
           teasers {


### PR DESCRIPTION
#### What problem is this solving?

Our shelves are usign the product-spot-price and without this field on products it can't appears.

![image](https://user-images.githubusercontent.com/49173685/93087389-d6df1100-f66e-11ea-9690-46761a759a0c.png)

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://vtexshelf--carrefourbr.myvtex.com/dia-das-criancas-teste)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/49173685/93087704-51a82c00-f66f-11ea-981b-e810194d5081.png)
