### PR TITLE
Add productClusters and spotPrice to productRecommendations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `productClusters` and `spotPrice` to `productRecommendations` query.
 
 ## [1.43.1] - 2020-09-17
 ### Security

--- a/react/queries/productRecommendations.gql
+++ b/react/queries/productRecommendations.gql
@@ -75,15 +75,16 @@ query ProductRecommendations(
             NumberOfInstallments
             Name
           }
-          Price
+          AvailableQuantity
+          CacheVersionUsedToCallCheckout
           ListPrice
+          Price
+          PriceValidUntil
           PriceWithoutDiscount
           RewardValue
-          PriceValidUntil
-          AvailableQuantity
+          spotPrice
           Tax
           taxPercentage
-          CacheVersionUsedToCallCheckout
           teasers {
             name
           }
@@ -92,6 +93,10 @@ query ProductRecommendations(
           }
         }
       }
+    }
+    productClusters {
+      id
+      name
     }
     properties {
       name


### PR DESCRIPTION
#### What problem is this solving?

Add missing fields to productRecommendations query.

#### How to test it?

https://brenofield--sarachoneumaticos.myvtex.com/215-65-r16-michelin-primacy-4-102h/p

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/284515/93812959-bd1e6a80-fc28-11ea-8f17-446ab4907bc4.png)


#### Describe alternatives you've considered, if any.

I considered #239, but we should test it more.

#### Related to / Depends on

n/a

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
