### PR TITLE
Stop event bubbling for navigation arrows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Navigation arrows would not work when the `slider` was placed inside an `<a>` tag. This is the case if you were to place a `slider` inside of a `product-summary`.
 
 ## [1.44.0] - 2020-09-22
 ### Added

--- a/react/components/ShelfContent.js
+++ b/react/components/ShelfContent.js
@@ -191,7 +191,7 @@ class ShelfContent extends Component {
                 key={path(['productId'], item) || index}
                 defaultWidth={DEFAULT_SHELF_ITEM_WIDTH}
               >
-                <ShelfItem item={item} summary={summary}/>
+                <ShelfItem item={item} summary={summary} />
               </Slide>
             ))}
           </Slider>

--- a/react/components/ShelfContent.js
+++ b/react/components/ShelfContent.js
@@ -110,7 +110,7 @@ class ShelfContent extends Component {
     return (
       <div
         className={containerClasses}
-        onClick={(e) => {
+        onClick={e => {
           if (e) {
             e.stopPropagation()
             e.preventDefault()

--- a/react/components/ShelfContent.js
+++ b/react/components/ShelfContent.js
@@ -110,7 +110,13 @@ class ShelfContent extends Component {
     return (
       <div
         className={containerClasses}
-        onClick={onClick}
+        onClick={(e) => {
+          if (e) {
+            e.stopPropagation()
+            e.preventDefault()
+          }
+          onClick(e)
+        }}
         role="button"
         tabIndex="0"
         onKeypress={e => e.key === 'Enter' || (e.key === ' ' && onClick(e))}
@@ -185,7 +191,7 @@ class ShelfContent extends Component {
                 key={path(['productId'], item) || index}
                 defaultWidth={DEFAULT_SHELF_ITEM_WIDTH}
               >
-                <ShelfItem item={item} summary={summary} />
+                <ShelfItem item={item} summary={summary}/>
               </Slide>
             ))}
           </Slider>


### PR DESCRIPTION
#### What problem is this solving?
Navigation arrows would not work when the `slider` was placed inside an `<a>` tag. This is the case if you were to place a `slider` inside of a `product-summary`. In our case, the `related-products` shelf is using the deprecated version of the slider.

#### How to test it?

[Workspace](https://createbundle--fstudioqa.myvtex.com/aparate-foto/aparate-foto-dslr/aparate-foto-dslr-profesionisti?map=departament,categorie,subcategorie)

#### Screenshots or example usage:
Before:
![Before](https://user-images.githubusercontent.com/68231117/97704446-121c8e80-1abb-11eb-96af-1b0edb2de41b.gif)

After:
![After](https://user-images.githubusercontent.com/68231117/97704458-16e14280-1abb-11eb-8335-e60b220f49b6.gif)

