### PR TITLE
Fix prop maxItems not being passed down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prop `maxItems`.
 
 ## [1.44.1] - 2020-11-04
 ### Fixed

--- a/react/Shelf.js
+++ b/react/Shelf.js
@@ -26,6 +26,7 @@ const Shelf = props => {
   const {
     data,
     paginationDotsVisibility = 'visible',
+    maxItems,
     productList = ProductList.defaultProps,
   } = props
   let { trackingId } = props
@@ -46,6 +47,7 @@ const Shelf = props => {
 
   const productListProps = {
     ...productList,
+    maxItems,
     isMobile,
     loading,
     paginationDotsVisibility,
@@ -92,6 +94,7 @@ Shelf.propTypes = {
   /** ProductList schema configuration */
   productList: PropTypes.shape(productListSchemaPropTypes),
   trackingId: PropTypes.string,
+  maxItems: PropTypes.number,
 }
 
 const parseFilters = ({ id, value }) => `specificationFilter_${id}:${value}`


### PR DESCRIPTION
#### What problem is this solving?

maxItems prop was not being passed down to the list component

For it to work the user had to write the component like this:

```jsonc
{
  "shelf#test": {
    "blocks": [
      "product-summary.shelf"
    ],
    "props": {
      "orderBy": "",
      "category": "apparel---accessories",
      "maxItems": 30, 
      "productList": {
        "maxItems": 30 // <--- this shouldn't be needed
      }
    }
  }
}
```

This PR make it work like so:

```jsonc
{
  "shelf#test": {
    "blocks": [
      "product-summary.shelf"
    ],
    "props": {
      "orderBy": "",
      "category": "apparel---accessories",
      "maxItems": 30
    }
  }
}
```

#### How to test it?

https://shelf--storecomponents.myvtex.com/

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/284515/100385005-46269900-3000-11eb-829f-8b43c1ace413.png)

#### Describe alternatives you've considered, if any.

n/a

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/NEluJn2i7t1k7wnrX5/giphy.gif)
