### PR TITLE
Add Cluster Highlights to Product Recommendations Query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `clusterHighlights` to `ProductRecommendations` query.
+
 ## [1.45.0] - 2021-06-09
 ### Added
 - List name to GTM `productClick` event.

--- a/react/queries/productRecommendations.gql
+++ b/react/queries/productRecommendations.gql
@@ -94,6 +94,10 @@ query ProductRecommendations(
         }
       }
     }
+    clusterHighlights {
+      id
+      name
+    }
     productClusters {
       id
       name


### PR DESCRIPTION
#### What problem is this solving?

 Fixed the product-highlights rendering problem inside a shelf.

#### How to test it?

[Workspace](https://plp--sbdsefuat.myvtex.com/ad68-612bs/p?__bindingAddress=catalog.sef.ao.sbd-nonprod.com/en-US/catalog-global)

#### Screenshots or example usage:

Before 

![Summary 1](https://user-images.githubusercontent.com/85863093/128134079-f5becf79-7a28-42cb-91aa-ac2c2d67090f.JPG)

After

![Summary 2](https://user-images.githubusercontent.com/85863093/128134103-4b24a1ea-bb98-4d4a-ba39-e7ff0973e60d.JPG)

#### Related to / Depends on

Related to product-highlights

