### PR TITLE
Hideunavailable related products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `hideOutOfStock` prop to `RelatedProducts` shelf
+- `hideOutOfStockItems` prop to `RelatedProducts` shelf
 ## [1.45.0] - 2021-06-09
 ### Added
 - List name to GTM `productClick` event.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added
+- `hideOutOfStock` prop to `RelatedProducts` shelf
 ## [1.45.0] - 2021-06-09
 ### Added
 - List name to GTM `productClick` event.

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,6 +83,7 @@ The `list-context.product-list` is the block responsible for performing the Grap
 | Prop name        | Type                | Description                                                                                                                                            | Default value                     |
 | ---------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------- |
 | `recommendation` | `Enum`              | Type of recommendations that will be displayed in the Shelf. Possible values: `similars`, `suggestions`, `accessories` (these first three depend on the product's data given in the admin's catalog) and `view`, `buy`, `viewandBought` (These 3 are automatically generated according to the store’s activity) | `similars` |
+| `hideOutOfStock` | `Boolean` | Whether out of stock items should be hidden (`true`) or not (`false`) | `false` |
 | `productList`    | `ProductListSchema` | Product list schema. `See ProductListSchema`                                                                                                           | -                                 |
 
 `ProductListSchema`:

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,7 +83,7 @@ The `list-context.product-list` is the block responsible for performing the Grap
 | Prop name        | Type                | Description                                                                                                                                            | Default value                     |
 | ---------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------- |
 | `recommendation` | `Enum`              | Type of recommendations that will be displayed in the Shelf. Possible values: `similars`, `suggestions`, `accessories` (these first three depend on the product's data given in the admin's catalog) and `view`, `buy`, `viewandBought` (These 3 are automatically generated according to the store’s activity) | `similars` |
-| `hideOutOfStock` | `Boolean` | Whether out of stock items should be hidden (`true`) or not (`false`) | `false` |
+| `hideOutOfStockItems` | `Boolean` | Whether out of stock items should be hidden (`true`) or not (`false`) | `false` |
 | `productList`    | `ProductListSchema` | Product list schema. `See ProductListSchema`                                                                                                           | -                                 |
 
 `ProductListSchema`:

--- a/messages/context.json
+++ b/messages/context.json
@@ -6,6 +6,7 @@
   "admin/editor.shelf.collection.title": "admin/editor.shelf.collection.title",
   "admin/editor.shelf.orderBy.title": "admin/editor.shelf.orderBy.title",
   "admin/editor.shelf.hideUnavailableItems": "admin/editor.shelf.hideUnavailableItems",
+  "admin/editor.shelf.hideOutOfStockItems": "admin/editor.shelf.hideOutOfStock",
   "admin/editor.shelf.skusFilter": "admin/editor.shelf.skusFilter",
   "admin/editor.shelf.skusFilter.description": "admin/editor.shelf.skusFilter.description",
   "admin/editor.shelf.skusFilter.none": "admin/editor.shelf.skusFilter.none",

--- a/messages/context.json
+++ b/messages/context.json
@@ -6,7 +6,7 @@
   "admin/editor.shelf.collection.title": "admin/editor.shelf.collection.title",
   "admin/editor.shelf.orderBy.title": "admin/editor.shelf.orderBy.title",
   "admin/editor.shelf.hideUnavailableItems": "admin/editor.shelf.hideUnavailableItems",
-  "admin/editor.shelf.hideOutOfStockItems": "admin/editor.shelf.hideOutOfStock",
+  "admin/editor.shelf.hideOutOfStockItems": "admin/editor.shelf.hideOutOfStockItems",
   "admin/editor.shelf.skusFilter": "admin/editor.shelf.skusFilter",
   "admin/editor.shelf.skusFilter.description": "admin/editor.shelf.skusFilter.description",
   "admin/editor.shelf.skusFilter.none": "admin/editor.shelf.skusFilter.none",

--- a/messages/en.json
+++ b/messages/en.json
@@ -6,6 +6,7 @@
   "admin/editor.shelf.collection.title": "Collection",
   "admin/editor.shelf.orderBy.title": "List Ordenation",
   "admin/editor.shelf.hideUnavailableItems": "Hide unavailable items",
+  "admin/editor.shelf.hideOutOfStockItems": "Hide out of stock items",
   "admin/editor.shelf.skusFilter": "SKUs Filter",
   "admin/editor.shelf.skusFilter.description": "Setting the first available filter makes your query much faster!",
   "admin/editor.shelf.skusFilter.none": "None",

--- a/messages/es.json
+++ b/messages/es.json
@@ -6,7 +6,7 @@
   "admin/editor.shelf.collection.title": "Colección",
   "admin/editor.shelf.orderBy.title": "Ordenación de la Lista",
   "admin/editor.shelf.hideUnavailableItems": "Ocultar artículos no disponibles",
-  "admin/editor.shelf.hideOutOfStockItems": "Ocultar artículos agotados",
+  "admin/editor.shelf.hideOutOfStockItems": "Ocultar ítems sin stock",
   "admin/editor.shelf.skusFilter": "Filtro de SKUs",
   "admin/editor.shelf.skusFilter.description": "¡Establecer el primer iten disponible agiliza su consulta!",
   "admin/editor.shelf.skusFilter.none": "Ninguno",

--- a/messages/es.json
+++ b/messages/es.json
@@ -6,6 +6,7 @@
   "admin/editor.shelf.collection.title": "Colección",
   "admin/editor.shelf.orderBy.title": "Ordenación de la Lista",
   "admin/editor.shelf.hideUnavailableItems": "Ocultar artículos no disponibles",
+  "admin/editor.shelf.hideOutOfStockItems": "Ocultar artículos agotados",
   "admin/editor.shelf.skusFilter": "Filtro de SKUs",
   "admin/editor.shelf.skusFilter.description": "¡Establecer el primer iten disponible agiliza su consulta!",
   "admin/editor.shelf.skusFilter.none": "Ninguno",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -6,6 +6,7 @@
   "admin/editor.shelf.collection.title": "Coleção",
   "admin/editor.shelf.orderBy.title": "Ordenação da Lista",
   "admin/editor.shelf.hideUnavailableItems": "Esconder itens não disponíveis",
+  "admin/editor.shelf.hideOutOfStockItems": "Esconder itens fora de estoque",
   "admin/editor.shelf.skusFilter": "Filtro de SKUs",
   "admin/editor.shelf.skusFilter.description": "Configurando o valor de primeiro disponível faz sua query ser mais rápida!",
   "admin/editor.shelf.skusFilter.none": "Nenhum",

--- a/react/RelatedProducts.js
+++ b/react/RelatedProducts.js
@@ -34,7 +34,7 @@ const RelatedProducts = ({
   productList,
   recommendation: cmsRecommendation,
   trackingId: rawTrackingId,
-  hideOutOfStock,
+  hideOutOfStockItems,
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
   const { isMobile } = useDevice()
@@ -68,7 +68,7 @@ const RelatedProducts = ({
   }, [productId, recommendation])
 
   const checkForOutOfStock = (productRecommendations = []) => {
-    return hideOutOfStock
+    return hideOutOfStockItems
       ? filterOutOfStock(productRecommendations)
       : productRecommendations
   }
@@ -123,7 +123,7 @@ RelatedProducts.propTypes = {
   /** ProductList schema configuration */
   productList: PropTypes.shape(productListSchemaPropTypes),
   trackingId: PropTypes.string,
-  hideOutOfStock: PropTypes.bool,
+  hideOutOfStockItems: PropTypes.bool,
 }
 
 RelatedProducts.defaultProps = {
@@ -132,7 +132,7 @@ RelatedProducts.defaultProps = {
     ...ProductList.defaultProps,
     titleText: 'Related Products',
   },
-  hideOutOfStock: false,
+  hideOutOfStockItems: false,
 }
 
 RelatedProducts.schema = {
@@ -163,7 +163,7 @@ RelatedProducts.schema = {
       ],
     },
     productList: ProductList.schema,
-    hideOutOfStock: {
+    hideOutOfStockItems: {
       title: 'admin/editor.shelf.hideOutOfStockItems',
       type: 'boolean',
       default: false,

--- a/react/RelatedProducts.js
+++ b/react/RelatedProducts.js
@@ -67,12 +67,6 @@ const RelatedProducts = ({
     }
   }, [productId, recommendation])
 
-  const checkForOutOfStock = (productRecommendations = []) => {
-    return hideOutOfStockItems
-      ? filterOutOfStock(productRecommendations)
-      : productRecommendations
-  }
-
   if (!productId) {
     return null
   }
@@ -88,10 +82,12 @@ const RelatedProducts = ({
         if (!data) {
           return null
         }
-        const { productRecommendations } = data
+        const { productRecommendations = [] } = data
 
         const productListProps = {
-          products: checkForOutOfStock(productRecommendations),
+          products: hideOutOfStockItems
+            ? filterOutOfStock(productRecommendations)
+            : productRecommendations,
           loading,
           ...productList,
           isMobile,

--- a/react/RelatedProducts.js
+++ b/react/RelatedProducts.js
@@ -12,6 +12,7 @@ import { useTreePath } from 'vtex.render-runtime'
 import productRecommendationsQuery from './queries/productRecommendations.gql'
 import ProductList from './components/ProductList'
 import { productListSchemaPropTypes } from './utils/propTypes'
+import { filterOutOfStock } from './utils/filterOutOfStock'
 
 const CSS_HANDLES = ['relatedProducts']
 
@@ -33,6 +34,7 @@ const RelatedProducts = ({
   productList,
   recommendation: cmsRecommendation,
   trackingId: rawTrackingId,
+  hideOutOfStock,
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
   const { isMobile } = useDevice()
@@ -65,6 +67,12 @@ const RelatedProducts = ({
     }
   }, [productId, recommendation])
 
+  const checkForOutOfStock = (productRecommendations = []) => {
+    return hideOutOfStock
+      ? filterOutOfStock(productRecommendations)
+      : productRecommendations
+  }
+
   if (!productId) {
     return null
   }
@@ -81,8 +89,9 @@ const RelatedProducts = ({
           return null
         }
         const { productRecommendations } = data
+
         const productListProps = {
-          products: productRecommendations || [],
+          products: checkForOutOfStock(productRecommendations),
           loading,
           ...productList,
           isMobile,
@@ -114,6 +123,7 @@ RelatedProducts.propTypes = {
   /** ProductList schema configuration */
   productList: PropTypes.shape(productListSchemaPropTypes),
   trackingId: PropTypes.string,
+  hideOutOfStock: PropTypes.bool,
 }
 
 RelatedProducts.defaultProps = {
@@ -122,6 +132,7 @@ RelatedProducts.defaultProps = {
     ...ProductList.defaultProps,
     titleText: 'Related Products',
   },
+  hideOutOfStock: false,
 }
 
 RelatedProducts.schema = {
@@ -152,6 +163,11 @@ RelatedProducts.schema = {
       ],
     },
     productList: ProductList.schema,
+    hideOutOfStock: {
+      title: 'admin/editor.shelf.hideOutOfStockItems',
+      type: 'boolean',
+      default: false,
+    },
   },
 }
 

--- a/react/utils/filterOutOfStock.js
+++ b/react/utils/filterOutOfStock.js
@@ -1,5 +1,4 @@
-export function filterOutOfStock(products) {
-  if (!products?.length) return []
+export function filterOutOfStock(products = []) {
   return products.filter(
     product => product.items[0]?.sellers[0]?.commertialOffer?.AvailableQuantity
   )

--- a/react/utils/filterOutOfStock.js
+++ b/react/utils/filterOutOfStock.js
@@ -1,0 +1,6 @@
+export function filterOutOfStock(products) {
+  if (!products?.length) return []
+  return products.filter(
+    product => product.items[0]?.sellers[0]?.commertialOffer?.AvailableQuantity
+  )
+}


### PR DESCRIPTION
#### What problem is this solving?

Adds the possibility to hide out of stock products from RelatedProducts shelf

#### How to test it?

Link it to a dev workspace and add `hideOutOfStockItems` prop to any `shelf.relatedProducts`

[Workspace](https://claudiuhideunavailable--iviteb.myvtex.com/)


#### Screenshots or example usage:

![before](https://user-images.githubusercontent.com/73105476/131500129-7576c815-5045-4be3-bd55-d54611169cd9.png)
)
![after](https://user-images.githubusercontent.com/73105476/131500178-352600db-172c-49a6-8de9-bc018997f751.png)

#### Describe alternatives you've considered, if any.

I've first tried to change the query by adding `isAvailablePerSalesChannel` param in search-resolver app, but it didn't worked.

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
