### PR TITLE
Add suport to configure instalment criteria

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,7 @@ Now, you can use all the blocks exported by the `shelf` app. Check out the compl
 | `recommendation` | `Enum`              | Type of recommendations that will be displayed in the Shelf. Possible values: `similars`, `suggestions`, `accessories` (these first three depend on the product's data given in the admin's catalog) and `view`, `buy`, `viewandBought` (These 3 are automatically generated according to the store’s activity) | `similars` |
 | `hideOutOfStockItems` | `Boolean` | Whether out of stock items should be hidden (`true`) or not (`false`) | `false` |
 | `productList`    | `ProductListSchema` | Product list schema. See `ProductListSchema`                                                                                                           | -                                 |
-| `installmentCriteria`  | `InstallmentCriteriaEnum`              | Control what price to be shown when price has different installments (`"MAX_WITHOUT_INTEREST"` | `"MAX_WITH_INTEREST"`) options.                                                                                                                              | `"MAX_WITHOUT_INTEREST"` |
+| `installmentCriteria`  | `InstallmentCriteriaEnum`              | Control what price to be shown when price has different installments (`"MAX_WITHOUT_INTEREST"` / `"MAX_WITH_INTEREST"`) options.                                                                                                                              | `"MAX_WITHOUT_INTEREST"` |
 
 
 `ProductListSchema`:

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,8 @@ Now, you can use all the blocks exported by the `shelf` app. Check out the compl
 | `recommendation` | `Enum`              | Type of recommendations that will be displayed in the Shelf. Possible values: `similars`, `suggestions`, `accessories` (these first three depend on the product's data given in the admin's catalog) and `view`, `buy`, `viewandBought` (These 3 are automatically generated according to the store’s activity) | `similars` |
 | `hideOutOfStockItems` | `Boolean` | Whether out of stock items should be hidden (`true`) or not (`false`) | `false` |
 | `productList`    | `ProductListSchema` | Product list schema. See `ProductListSchema`                                                                                                           | -                                 |
+| `installmentCriteria`  | `InstallmentCriteriaEnum`              | Control what price to be shown when price has different installments (`"MAX_WITHOUT_INTEREST"` | `"MAX_WITH_INTEREST"`) options.                                                                                                                              | `"MAX_WITHOUT_INTEREST"` |
+
 
 `ProductListSchema`:
 

--- a/react/RelatedProducts.js
+++ b/react/RelatedProducts.js
@@ -35,6 +35,7 @@ const RelatedProducts = ({
   recommendation: cmsRecommendation,
   trackingId: rawTrackingId,
   hideOutOfStockItems,
+  installmentCriteria = 'MAX_WITHOUT_INTEREST'
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
   const { isMobile } = useDevice()
@@ -64,8 +65,9 @@ const RelatedProducts = ({
     return {
       identifier: { field: 'id', value: productId },
       type: recommendation,
+      installmentCriteria:installmentCriteria
     }
-  }, [productId, recommendation])
+  }, [productId, recommendation,installmentCriteria])
 
   if (!productId) {
     return null
@@ -120,6 +122,11 @@ RelatedProducts.propTypes = {
   productList: PropTypes.shape(productListSchemaPropTypes),
   trackingId: PropTypes.string,
   hideOutOfStockItems: PropTypes.bool,
+  /**
+   * Control what price to be shown when price has different installments options.
+   * @default "MAX_WITHOUT_INTEREST"
+   */
+   installmentCriteria: 'MAX_WITHOUT_INTEREST' | 'MAX_WITH_INTEREST'
 }
 
 RelatedProducts.defaultProps = {
@@ -129,6 +136,7 @@ RelatedProducts.defaultProps = {
     titleText: 'Related Products',
   },
   hideOutOfStockItems: false,
+  installmentCriteria:'MAX_WITHOUT_INTEREST'
 }
 
 RelatedProducts.schema = {

--- a/react/Shelf.js
+++ b/react/Shelf.js
@@ -28,6 +28,7 @@ const Shelf = props => {
     paginationDotsVisibility = 'visible',
     maxItems,
     productList = ProductList.defaultProps,
+    installmentCriteria = 'MAX_WITHOUT_INTEREST'
   } = props
   let { trackingId } = props
   const treePath = useTreePath()
@@ -53,6 +54,7 @@ const Shelf = props => {
     paginationDotsVisibility,
     products: filteredProducts,
     trackingId,
+    installmentCriteria
   }
 
   if (loading) {
@@ -96,6 +98,11 @@ Shelf.propTypes = {
   productList: PropTypes.shape(productListSchemaPropTypes),
   trackingId: PropTypes.string,
   maxItems: PropTypes.number,
+  /**
+   * Control what price to be shown when price has different installments options.
+   * @default "MAX_WITHOUT_INTEREST"
+   */
+   installmentCriteria: 'MAX_WITHOUT_INTEREST' | 'MAX_WITH_INTEREST'
 }
 
 const parseFilters = ({ id, value }) => `specificationFilter_${id}:${value}`
@@ -111,6 +118,7 @@ const options = {
     specificationFilters = [],
     maxItems = ProductList.defaultProps.maxItems,
     skusFilter,
+    installmentCriteria
   }) => ({
     ssr: true,
     variables: {
@@ -122,6 +130,7 @@ const options = {
       to: maxItems - 1,
       hideUnavailableItems: toBoolean(hideUnavailableItems),
       skusFilter,
+      installmentCriteria
     },
   }),
 }

--- a/react/queries/productRecommendations.gql
+++ b/react/queries/productRecommendations.gql
@@ -1,6 +1,7 @@
 query ProductRecommendations(
   $identifier: ProductUniqueIdentifier
   $type: CrossSelingInputEnum
+  $installmentCriteria: InstallmentsCriteria = MAX_WITHOUT_INTEREST
 ) {
   productRecommendations(identifier: $identifier, type: $type)
     @context(provider: "vtex.search-graphql") {
@@ -68,7 +69,7 @@ query ProductRecommendations(
         addToCartLink
         sellerDefault
         commertialOffer {
-          Installments(criteria: MAX) {
+          Installments(criteria: $installmentCriteria) {
             Value
             InterestRate
             TotalValuePlusInterestRate

--- a/react/queries/productsQuery.gql
+++ b/react/queries/productsQuery.gql
@@ -7,6 +7,7 @@ query Products(
   $to: Int
   $hideUnavailableItems: Boolean = false
   $skusFilter: ItemsFilter = ALL_AVAILABLE
+  $installmentCriteria: InstallmentsCriteria = MAX_WITHOUT_INTEREST
 ) {
   products(
     category: $category
@@ -77,7 +78,7 @@ query Products(
         sellerId
         sellerName
         commertialOffer {
-          Installments(criteria: MAX) {
+          Installments(criteria: $installmentCriteria) {
             Value
             InterestRate
             TotalValuePlusInterestRate


### PR DESCRIPTION
#### What problem is this solving?

The block `shelf` and `shelf.relatedProducts` no have suport to define instalment criteria when load products.


#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/16208496/171858137-6d92a545-ec42-47cf-a617-c90b9ee3001a.png)

