### PR TITLE
chore: Better clarify props for `Shelf` and `RelatedProducts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Documentation to better clarify the props for the `Shelf` and `RelatedProducts` components.
+
 ## [1.47.2] - 2022-02-01
 ### Changed
 - Deprecated `shelf.relatedProducts` block

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,25 @@ Now, you can use all the blocks exported by the `shelf` app. Check out the compl
 }
 ```
 
+>⚠️ Warning
+>
+> Note that for hiding unavailable/out-of-stock items, there are 2 different props: `hideUnavailableItems` and `hideOutOfStockItems`. They do the same thing, but each is used by a different component: `Shelf` and `RelatedProducts`, respectively.
+
+### Shelf
+
+| Prop name        | Type                | Description                                                                                                                                            | Default value                     |
+| ---------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------- |
+| `category` | `String`              | The category ID |
+| `collection` | `String`              | The collection ID |
+| `orderBy` | `Enum`              | `OrderByTopSaleDESC`, `OrderByPriceDESC`, `OrderByPriceASC`, `OrderByNameASC`, `OrderByNameDESC`, `OrderByReleaseDateDESC`, `OrderByBestDiscountDESC` |
+| `hideUnavailableItems` | `Boolean` | Whether out of stock items should be hidden (`true`) or not (`false`) | `false` |
+| `paginationDotsVisibility` | `Enum`              | `visible`, `hidden`, `mobileOnly`, `desktopOnly` |
+| `productList`    | `ProductListSchema` | Product list schema. See `ProductListSchema`                                                                                                           | -                                 |
+| `trackingId` | `String`              | Name to show in the Google Analytics. If nothing is passed it will use the name of the block instead |
+| `maxItems` | `Number`              | Max items |
+
+### RelatedProducts
+
 | Prop name        | Type                | Description                                                                                                                                            | Default value                     |
 | ---------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------- |
 | `recommendation` | `Enum`              | Type of recommendations that will be displayed in the Shelf. Possible values: `similars`, `suggestions`, `accessories` (these first three depend on the product's data given in the admin's catalog) and `view`, `buy`, `viewandBought` (These 3 are automatically generated according to the store’s activity) | `similars` |


### PR DESCRIPTION
#### What problem is this solving?

Clarify in the documentation which props belong to each component. For instance, it wasn't clear that the `hideOutOfStockItems` prop was associated only with the `RelatedProduct` component and that for the `Shelf` component, one should use the `hideUnavailableItems` props instead. By breaking the document in sections we can specify this better.

#### Screenshots or example usage:

[Before](https://github.com/vtex-apps/shelf/blob/c4acc6231fa67ed7f6dfa2aa8e928d6d2ec2e331/docs/README.md#configuration)|[After](https://github.com/vtex-apps/shelf/blob/acb407d0f173054c12385b52fde755b4e9aa91a3/docs/README.md#configuration)
-|-
![CleanShot 2022-12-19 at 11 07 02](https://user-images.githubusercontent.com/381395/208444033-c2a77b21-0999-43c5-a257-9829236d98f3.png)|![CleanShot 2022-12-19 at 11 06 57](https://user-images.githubusercontent.com/381395/208444051-094e3eb8-89aa-4a60-a4c4-a861d604e41c.png)
