### PR TITLE
feat: add groupBy prop in recommendation shelf

### DIFF
--- a/react/RelatedProducts.js
+++ b/react/RelatedProducts.js
@@ -32,6 +32,7 @@ const fixRecommendation = recommendation => {
 const RelatedProducts = ({
   productQuery,
   productList,
+  groupBy,
   recommendation: cmsRecommendation,
   trackingId: rawTrackingId,
   hideOutOfStockItems,
@@ -64,8 +65,9 @@ const RelatedProducts = ({
     return {
       identifier: { field: 'id', value: productId },
       type: recommendation,
+      groupBy
     }
-  }, [productId, recommendation])
+  }, [productId, recommendation, groupBy])
 
   if (!productId) {
     return null
@@ -128,6 +130,7 @@ RelatedProducts.defaultProps = {
     ...ProductList.defaultProps,
     titleText: 'Related Products',
   },
+  groupBy: 'PRODUCT',
   hideOutOfStockItems: false,
 }
 
@@ -156,6 +159,20 @@ RelatedProducts.schema = {
         'admin/editor.relatedProducts.accessories',
         'admin/editor.relatedProducts.viewAndBought',
         'admin/editor.relatedProducts.suggestions',
+      ],
+    },
+    groupBy:{
+      title: 'admin/editor.relatedProducts.groupBy.title',
+      description: 'admin/editor.relatedProducts.groupBy.description',
+      type: 'string',
+      default: RelatedProducts.defaultProps.groupBy,
+      enum: [
+        'PRODUCT',
+        'NONE',
+      ],
+      enumNames: [
+        'admin/editor.relatedProducts.groupBy.product',
+        'admin/editor.relatedProducts.groupBy.none'
       ],
     },
     productList: ProductList.schema,

--- a/react/queries/productRecommendations.gql
+++ b/react/queries/productRecommendations.gql
@@ -1,8 +1,9 @@
 query ProductRecommendations(
   $identifier: ProductUniqueIdentifier
   $type: CrossSelingInputEnum
+  $groupBy: CrossSelingGroupByEnum
 ) {
-  productRecommendations(identifier: $identifier, type: $type)
+  productRecommendations(identifier: $identifier, type: $type, groupBy: $groupBy)
     @context(provider: "vtex.search-graphql") {
     cacheId
     productId


### PR DESCRIPTION
#### What problem is this solving?

We have a limitation in Recommendation queries where we always group by products, but, some customers, especially when talking about fashion segments, want to show also individual SKUs instead, this feature is responsible for allowing that.

Also, there's another limitation presented here that we are trying to cover. When grouping by products and calling the catalog cross selling API, we do a reduced search, in this reduced search, the total quantity of products returned is limited by 12, but, if we don't use this parameter the limit is 50, so, we are also increasing the possibility of the number of products returned by this query

#### How to test it?

[Workspace](https://iespinoza--oficinareserva.myvtex.com/tenis-vert-v-10-branco-e-verde-0081603102/p)
[Site Editor](https://iespinoza--oficinareserva.myvtex.com/admin/cms/site-editor/tenis-vert-v-10-branco-e-verde-0081603102/p)

Add the block shelf.relatedProducts with the prop groupBy

```jsonc
  "shelf.relatedProducts": {
    "blocks": ["product-summary.shelf"],
    "props": {
      "recommendation": "similars",
      "groupBy": "NONE"
    }    
  },
```

<img width="272" alt="image" src="https://github.com/vtex-apps/shelf/assets/13649073/4be6cff4-236b-4d25-9ec9-ba2dde0047b6">


#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

https://github.com/vtex-apps/search-resolver/pull/467
https://github.com/vtex-apps/search-graphql/pull/135

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYTFkcnphNnc0MDkxbXp0MWk4Yjc4Z3JyY2dnd2xvM2ptemVrMjFodyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/m25KXX5foCPaa2ptJl/giphy.gif)
