### PR TITLE
Add "infinite" property to the related products shelf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- infinite prop in `shelf.relatedProducts`
+
 ## [1.48.0] - 2024-03-21
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -78,7 +78,7 @@ Now, you can use all the blocks exported by the `shelf` app. See the full list b
 | `minItemsPerPage` | `number` | Minimum number of items per shelf slides. This prop defines how many items will be displayed on the related product shelf, even in the smallest screen size. Its value can be a float, which means that you can choose a multiple of `0.5` to indicate that you want to show a *peek* of the next slide on the shelf. | `1` |
 | `itemsPerPage` | `number` | Maximum number of items per shelf slides. This prop defines how many items will be displayed on the related product shelf, even in the largest screen size. Its value can be a float, which means that you can choose a multiple of `0.5` to indicate that you want to show a *peek* of the next slide on the shelf.  | `5` |
 | `summary` | `object`  | Schema declaring the desired related product shelf items. This prop object must contain the [`product-summary.shelf` block props](https://developers.vtex.com/docs/guides/vtex-product-summary#configuration). | `undefined` |
-' `infinite` | `boolean` | Whether the list should be infinite (looped) (`true`) or not (`false`). | `true` |
+' `infinite` | `boolean` | Determines whether the list should be infinite (`true`) or not (`false`). When this prop is set as `false`, the slider will have an explicit end for users. | `true` |
 
 ## Customization
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -78,6 +78,7 @@ Now, you can use all the blocks exported by the `shelf` app. See the full list b
 | `minItemsPerPage` | `number` | Minimum number of items per shelf slides. This prop defines how many items will be displayed on the related product shelf, even in the smallest screen size. Its value can be a float, which means that you can choose a multiple of `0.5` to indicate that you want to show a *peek* of the next slide on the shelf. | `1` |
 | `itemsPerPage` | `number` | Maximum number of items per shelf slides. This prop defines how many items will be displayed on the related product shelf, even in the largest screen size. Its value can be a float, which means that you can choose a multiple of `0.5` to indicate that you want to show a *peek* of the next slide on the shelf.  | `5` |
 | `summary` | `object`  | Schema declaring the desired related product shelf items. This prop object must contain the [`product-summary.shelf` block props](https://developers.vtex.com/docs/guides/vtex-product-summary#configuration). | `undefined` |
+' `infinite` | `boolean` | Whether the list should be infinite (looped) (`true`) or not (`false`). | `true` |
 
 ## Customization
 

--- a/react/components/ProductList.js
+++ b/react/components/ProductList.js
@@ -38,6 +38,7 @@ const ProductList = ({
   paginationDotsVisibility,
   navigationStep: navigationStepProp,
   trackingId,
+  infinite,
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
   const navigationStep = Number.isNaN(parseInt(navigationStepProp, 10))
@@ -77,6 +78,7 @@ const ProductList = ({
             minItemsPerPage={minItemsPerPage}
             paginationDotsVisibility={paginationDotsVisibility}
             listName={listName}
+            infinite={infinite}
           />
         )}
       </ReactResizeDetector>
@@ -95,6 +97,7 @@ ProductList.defaultProps = {
   showTitle: true,
   titleText: null,
   isMobile: false,
+  infinite: true,
 }
 
 ProductList.propTypes = {
@@ -112,6 +115,7 @@ ProductList.propTypes = {
     'mobileOnly',
   ]),
   trackingId: PropTypes.string,
+  infinite: PropTypes.bool,
   ...productListSchemaPropTypes,
 }
 

--- a/react/components/ShelfContent.js
+++ b/react/components/ShelfContent.js
@@ -144,6 +144,7 @@ class ShelfContent extends Component {
       minItemsPerPage,
       paginationDotsVisibility,
       listName,
+      infinite,
     } = this.props
 
     const { currentSlide } = this.state
@@ -170,7 +171,7 @@ class ShelfContent extends Component {
           className={`${cssHandles.sliderContainer} w-100 mw9`}
         >
           <Slider
-            loop
+            loop={infinite}
             easing="ease"
             duration={500}
             minPerPage={roundedMinItems}
@@ -257,6 +258,8 @@ ShelfContent.propTypes = {
   gap: shelfContentPropTypes.gap,
   /** Title of the shelf */
   listName: shelfContentPropTypes.listName,
+  /** Is infinite */
+  infinite: shelfContentPropTypes.infinite,
 }
 
 export default withCssHandles(CSS_HANDLES)(ShelfContent)

--- a/react/utils/propTypes.js
+++ b/react/utils/propTypes.js
@@ -107,4 +107,6 @@ export const shelfContentPropTypes = {
   gap: PropTypes.oneOf(getGapPaddingValues()),
   /** Title of the shelf */
   listName: PropTypes.string.isRequired,
+  /** Is infinite */
+  infinite: PropTypes.bool,
 }


### PR DESCRIPTION
To add the "infinite" prop that will make users be able to choose whether they want the related products shelf be looped or not.

#### What problem is this solving?

There is no way to make the related products shelf be non infinite.

#### How to test it?

You can see the "infinite": false example here (use mobile layout):

https://devalex--dunnesstores.myvtex.com/crew-neck-button-front-cardigan-8672766blac/p

#### Screenshots or example usage:
Before
![Снимок экрана 2024-09-26 в 13 33 42](https://github.com/user-attachments/assets/f1cea9b6-ebdd-4dd2-acdd-49d1df285011)

After
![Снимок экрана 2024-09-26 в 13 33 30](https://github.com/user-attachments/assets/3db49f7a-b399-46ea-8949-8d3e876f37db)

